### PR TITLE
[#1] CI/CD 개선 및 옵저버빌리티 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	implementation 'io.micrometer:micrometer-tracing-bridge-otel' // 트레이싱
 	implementation 'io.opentelemetry:opentelemetry-exporter-otlp' // otel exporter
 	implementation 'net.ttddyy.observation:datasource-micrometer-spring-boot:1.1.2' // JDBC 트레이싱
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.kafka:spring-kafka'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
+
+	implementation 'io.micrometer:micrometer-tracing-bridge-otel' // 트레이싱
+	implementation 'io.opentelemetry:opentelemetry-exporter-otlp' // otel exporter
+	implementation 'net.ttddyy.observation:datasource-micrometer-spring-boot:1.1.2' // JDBC 트레이싱
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14")
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
 }
 
 tasks.named('test') {

--- a/k8s/helm-value.yaml
+++ b/k8s/helm-value.yaml
@@ -1,18 +1,2 @@
 image:
   tag: v0.1.0
-
-config: |
-  spring:
-    datasource:
-      driver-class-name: org.postgresql.Driver
-      url: jdbc:postgresql://story-database:5432/story
-
-    jpa:
-      hibernate:
-        ddl-auto: update
-      properties:
-        hibernate:
-          show_sql: true
-          format_sql: true
-          dialect: org.hibernate.dialect.PostgreSQLDialect
-      open-in-view: false

--- a/src/main/java/com/earseo/story/common/KafkaEvent.java
+++ b/src/main/java/com/earseo/story/common/KafkaEvent.java
@@ -1,0 +1,17 @@
+package com.earseo.story.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KafkaEvent<T> {
+    private String eventId;
+    private String eventType;
+    private String eventTime;
+    private T data;
+}

--- a/src/main/java/com/earseo/story/common/config/KafkaConfig.java
+++ b/src/main/java/com/earseo/story/common/config/KafkaConfig.java
@@ -1,0 +1,9 @@
+package com.earseo.story.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+}

--- a/src/main/java/com/earseo/story/common/config/ObjectMapperConfig.java
+++ b/src/main/java/com/earseo/story/common/config/ObjectMapperConfig.java
@@ -1,0 +1,19 @@
+package com.earseo.story.common.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+}
+

--- a/src/main/java/com/earseo/story/common/config/RedisConfig.java
+++ b/src/main/java/com/earseo/story/common/config/RedisConfig.java
@@ -1,0 +1,105 @@
+package com.earseo.story.common.config;
+
+import io.lettuce.core.ReadFrom;
+import io.lettuce.core.resource.ClientResources;
+import io.lettuce.core.tracing.MicrometerTracing;
+import io.micrometer.observation.ObservationRegistry;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisSentinelConfiguration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.database:0}")
+    private int database;
+
+    /**
+     * Standalone용
+     */
+    @Value("${spring.data.redis.host:localhost}")
+    private String host;
+    @Value("${spring.data.redis.port:6379}")
+    private int port;
+
+    @Bean
+    @Profile("test")
+    public RedisConnectionFactory standaloneRedisConnectionFactory(ClientResources clientResources) {
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+            .clientResources(clientResources).build();
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(host, port);
+        redisConfig.setDatabase(database);
+        return new LettuceConnectionFactory(redisConfig, clientConfig);
+    }
+
+    /**
+     * Sentinel용 (Production 환경과 동일)
+     */
+    @Value("${spring.data.redis.sentinel.master:valkey-master}")
+    private String sentinelMaster;
+    @Value("${spring.data.redis.sentinel.nodes:localhost:6379}")
+    private String sentinelNodes;
+    @Value("${spring.data.redis.password:}")
+    private String password;
+
+    @Bean
+    @Profile("!test")
+    public RedisConnectionFactory sentinelRedisConnectionFactory(ClientResources clientResources) {
+        // Sentinel 구성
+        RedisSentinelConfiguration sentinelConfig = new RedisSentinelConfiguration()
+            .master(sentinelMaster);
+
+        for (String node : sentinelNodes.split(",")) {
+            String[] addr = node.split(":");
+            sentinelConfig.sentinel(addr[0], Integer.parseInt(addr[1]));
+        }
+
+        sentinelConfig.setPassword(password);
+        sentinelConfig.setDatabase(database);
+
+        // 읽기 분산 전략 설정
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+            .clientResources(clientResources)
+            // 가능하면 Replica에서 읽고, 안 되면 Master에서 읽음
+            .readFrom(ReadFrom.REPLICA_PREFERRED)
+            .build();
+
+        return new LettuceConnectionFactory(sentinelConfig, clientConfig);
+    }
+
+    @Bean(name = "stringTemplate")
+    @Primary
+    public RedisTemplate<String, String> stringTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
+    }
+
+    @Bean
+    @Primary
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
+    }
+
+    @Bean
+    public ClientResources clientResources(ObservationRegistry observationRegistry) {
+        return ClientResources.builder()
+            .tracing(new MicrometerTracing(observationRegistry, "redis-cache"))
+            .build();
+    }
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,7 +1,7 @@
-config:
-  import:
-    - optional:file:/etc/secret/application-secret.yaml
 spring:
+  config:
+    import:
+      - optional:file:/etc/secret/application-secret.yaml
   datasource:
     driver-class-name: ${SPRING_DATASOURCE_DRIVER_CLASS_NAME:org.postgresql.Driver}
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/earseo}
@@ -16,6 +16,42 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: false
+  kafka:
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    template:
+      observation-enabled: true
+    listener:
+      observation-enabled: true
+      ack-mode: manual
+
+    consumer:
+      group-id: ${SPRING_KAFKA_CONSUMER_GROUP_ID:${spring.application.name}-consumer-group}
+      auto-offset-reset: earliest
+      key-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      properties:
+        spring.deserializer.key.delegate.class: org.apache.kafka.common.serialization.StringDeserializer
+        spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
+        spring.json.trusted.packages: "*"
+        spring.json.use.type.headers: false
+        spring.json.value.default.type: com.earseo.story.common.KafkaEvent
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: all
+      properties:
+        spring.json.add.type.headers: false
+    properties:
+      security.protocol: ${SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL:PLAINTEXT}
+      sasl.mechanism: ${SPRING_KAFKA_PROPERTIES_SASL_MECHANISM:PLAIN}
+      sasl.jaas.config: ${SPRING_KAFKA_PROPERTIES_SASL_JAAS_CONFIG:}
+  data:
+    redis:
+      password: ${VALKEY_PASSWORD}
+      sentinel:
+        master: ${SPRING_DATA_REDIS_SENTINEL_MASTER:valkey-master}
+        nodes: ${SPRING_DATA_REDIS_SENTINEL_NODES:localhost:26379}
+      database: 6
 
 otel:
   propagators:
@@ -31,6 +67,10 @@ management:
     web:
       exposure:
         include: prometheus,health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
   metrics:
     tags:
       application: ${spring.application.name}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,5 +1,31 @@
+config:
+  import:
+    - optional:file:/etc/secret/application-secret.yaml
 spring:
-  config:
-    import:
-      - file:/etc/config/application-config.yaml
-      - file:/etc/secret/application-secret.yaml
+  datasource:
+    driver-class-name: ${SPRING_DATASOURCE_DRIVER_CLASS_NAME:org.postgresql.Driver}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/earseo}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:1234}
+  jpa:
+    hibernate:
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}
+    properties:
+      hibernate:
+        show_sql: false
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    open-in-view: false
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus,health,info
+  metrics:
+    tags:
+      application: ${spring.application.name}
+
+logging:
+  level:
+    org.hibernate.SQL: ${LOGGING_LEVEL_ORG_HIBERNATE_SQL:debug}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -17,7 +17,16 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: false
 
+otel:
+  propagators:
+    - tracecontext
+    - b3
+    - baggage
 management:
+  otlp:
+    tracing:
+      endpoint: http://${NODE_IP:localhost}:4317
+      transport: grpc
   endpoints:
     web:
       exposure:
@@ -25,6 +34,10 @@ management:
   metrics:
     tags:
       application: ${spring.application.name}
+  tracing:
+    sampling:
+      probability: 1.0
+    enabled: true
 
 logging:
   level:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -14,12 +14,50 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: false
+  kafka:
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:${KAFKA_IP}:19092}
+    template:
+      observation-enabled: false
+    listener:
+      observation-enabled: false
+      ack-mode: manual
+
+    consumer:
+      group-id: ${SPRING_KAFKA_CONSUMER_GROUP_ID:${spring.application.name}-consumer-group}
+      auto-offset-reset: earliest
+      key-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      properties:
+        spring.deserializer.key.delegate.class: org.apache.kafka.common.serialization.StringDeserializer
+        spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
+        spring.json.trusted.packages: "*"
+        spring.json.use.type.headers: false
+        spring.json.value.default.type: com.earseo.story.common.KafkaEvent
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: all
+      properties:
+        spring.json.add.type.headers: false
+    properties:
+      security.protocol: ${SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL:PLAINTEXT}
+  data:
+    redis:
+      password: ${VALKEY_PASSWORD:valkeypass}
+      sentinel:
+        master: ${SPRING_DATA_REDIS_SENTINEL_MASTER:valkey-master}
+        nodes: ${SPRING_DATA_REDIS_SENTINEL_NODES:localhost:26379,localhost:26380,localhost:26381}
+      database: 6
 
 management:
   endpoints:
     web:
       exposure:
         include: prometheus,health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
   metrics:
     tags:
       application: ${spring.application.name}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,9 +1,9 @@
 spring:
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:userdb}
-    username: ${DB_USERNAME:user}
-    password: ${DB_PASSWORD:password}
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:15432}/${DB_NAME:postgres}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
 
   jpa:
     hibernate:
@@ -15,19 +15,15 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: false
 
-#  kafka:
-#    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
-#    consumer:
-#      group-id: ${KAFKA_CONSUMER_GROUP_ID:${spring.application.name}-group}
-#      auto-offset-reset: earliest
-#      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-#      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-#      properties:
-#        spring:
-#          json:
-#            trusted:
-#              packages: '*'
-#    producer:
-#      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-#      value-serializer: org.apache.kafka.common.serialization.StringSerializer
-#      acks: all
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus,health,info
+  metrics:
+    tags:
+      application: ${spring.application.name}
+
+logging:
+  level:
+    org.hibernate.SQL: ${LOGGING_LEVEL_ORG_HIBERNATE_SQL:debug}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -23,6 +23,8 @@ management:
   metrics:
     tags:
       application: ${spring.application.name}
+  tracing:
+    enabled: false
 
 logging:
   level:

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -14,20 +14,50 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: false
+  kafka:
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    template:
+      observation-enabled: false
+    listener:
+      observation-enabled: false
+      ack-mode: manual
 
-#  kafka:
-#    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
-#    consumer:
-#      group-id: ${KAFKA_CONSUMER_GROUP_ID:${spring.application.name}-group}
-#      auto-offset-reset: earliest
-#      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-#      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-#      properties:
-#        spring:
-#          json:
-#            trusted:
-#              packages: '*'
-#    producer:
-#      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-#      value-serializer: org.apache.kafka.common.serialization.StringSerializer
-#      acks: all
+    consumer:
+      group-id: ${SPRING_KAFKA_CONSUMER_GROUP_ID:${spring.application.name}-consumer-group}
+      auto-offset-reset: earliest
+      key-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      properties:
+        spring.deserializer.key.delegate.class: org.apache.kafka.common.serialization.StringDeserializer
+        spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
+        spring.json.trusted.packages: "*"
+        spring.json.use.type.headers: false
+        spring.json.value.default.type: com.earseo.story.common.KafkaEvent
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: all
+      properties:
+        spring.json.add.type.headers: false
+    properties:
+      security.protocol: ${SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL:PLAINTEXT}
+  data:
+    redis:
+      database: 6
+      host: localhost
+      port: 6379
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus,health,info
+  metrics:
+    tags:
+      application: ${spring.application.name}
+  tracing:
+    enabled: false
+
+logging:
+  level:
+    org.hibernate.SQL: ${LOGGING_LEVEL_ORG_HIBERNATE_SQL:debug}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,6 @@
 spring:
   application:
-    name: story
+    name: backend-story
   profiles:
     default: local
 server:


### PR DESCRIPTION
## 🧩 구현/변경 사항
- 헬름 `v0.1.1` 지원을 위해 value 파일과 application.yaml 파일을 수정했습니다.
- `OpenTelemetry exporter` 기반 트레이싱 설정을 했습니다.
- 쿠버네티스와 로컬의 미들웨어 환경에 적합한 Kafka Configuration과 Redis Configuration Bean을 작성했습니다.

---

## 참고
- [레디스](https://github.com/EarSEO/backend-story/blob/v0.1.0-alpha-5/src/main/java/com/earseo/story/controller/TestController.java)와 [카프카 프로듀서](https://github.com/EarSEO/backend-story/blob/v0.1.0-alpha-5/src/main/java/com/earseo/story/event/producer/TestProducer.java), [카프카 컨슈머](https://github.com/EarSEO/backend-story/blob/v0.1.0-alpha-5/src/main/java/com/earseo/story/event/consumer/TestConsumer.java) 활용이 어렵다면 예시코드를 확인해주세요.

closes #1 