### PR TITLE
[#4] 이야기 위치/키워드 기반 조회 및 CRUD

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.kafka:spring-kafka'
+
+	implementation 'ch.hsr:geohash:1.4.0' // Geohash
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.kafka:spring-kafka'
 
+	implementation 'org.hibernate.orm:hibernate-spatial' // hibernate-spatial
+	implementation 'org.locationtech.jts:jts-core:1.19.0'
 	implementation 'ch.hsr:geohash:1.4.0' // Geohash
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE' // AWS
 }
 
 tasks.named('test') {

--- a/k8s/helm-value.yaml
+++ b/k8s/helm-value.yaml
@@ -1,2 +1,2 @@
 image:
-  tag: v0.1.0
+  tag: v0.1.1

--- a/src/main/java/com/earseo/story/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/earseo/story/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.earseo.story.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/earseo/story/common/config/S3Config.java
+++ b/src/main/java/com/earseo/story/common/config/S3Config.java
@@ -1,0 +1,29 @@
+package com.earseo.story.common.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder
+            .standard()
+            .withRegion(region)
+            .withCredentials(new AWSStaticCredentialsProvider(credentials))
+            .build();
+    }
+}

--- a/src/main/java/com/earseo/story/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/earseo/story/common/exception/GlobalExceptionHandler.java
@@ -20,8 +20,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<BaseResponse<String>> handleBaseException(BaseException e) {
         ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
-                .status(errorCode.getHttpStatus())
-                .body(BaseResponse.onFailure(errorCode.getStatus(), errorCode.getMessage(), null));
+            .status(errorCode.getHttpStatus())
+            .body(BaseResponse.onFailure(errorCode.getStatus(), errorCode.getMessage(), null));
     }
 
     /**
@@ -30,15 +30,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<BaseResponse<String>> handleValidationException(MethodArgumentNotValidException e) {
         String errorMessage = e.getBindingResult()
-                .getFieldErrors()
-                .stream()
-                .findFirst()
-                .map(DefaultMessageSourceResolvable::getDefaultMessage)
-                .orElse("잘못된 요청입니다.");
+            .getFieldErrors()
+            .stream()
+            .findFirst()
+            .map(DefaultMessageSourceResolvable::getDefaultMessage)
+            .orElse("잘못된 요청입니다.");
 
         return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(BaseResponse.onFailure("ARGUMENT_ERROR", errorMessage, null));
+            .status(HttpStatus.BAD_REQUEST)
+            .body(BaseResponse.onFailure("ARGUMENT_ERROR", errorMessage, null));
     }
 
     /**
@@ -48,7 +48,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<BaseResponse<String>> handleUnexpectedException(Exception e) {
         log.error("서버 내부 오류 발생: ", e);
         return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(BaseResponse.onFailure("INTERNAL_SERVER_ERROR", "내부 서버 에러가 발생했습니다.", null));
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(BaseResponse.onFailure("INTERNAL_SERVER_ERROR", "내부 서버 에러가 발생했습니다.", null));
     }
 }

--- a/src/main/java/com/earseo/story/common/exception/StoryError.java
+++ b/src/main/java/com/earseo/story/common/exception/StoryError.java
@@ -7,8 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum StoryError implements ErrorCodeInterface {
-
-    STORY_ERROR("STR001", "스토리에러를 입력해주세요.", HttpStatus.I_AM_A_TEAPOT),
+    STORY_IMAGE_TOO_MANY("STR001", "이야기의 사진은 3개 이하여야 합니다.", HttpStatus.BAD_REQUEST),
+    ITS_NOT_YOU("STR002", "jwt 사용자와 입력 정보가 불일치 합니다.", HttpStatus.CONFLICT),
+    STORY_IMAGE_UPLOAD_FAILED("STR003", "이미지 업로드 중 오류가 발생했습니다.", HttpStatus.BAD_REQUEST),
     ;
 
     private final String status;
@@ -18,9 +19,9 @@ public enum StoryError implements ErrorCodeInterface {
     @Override
     public ErrorCode getErrorCode() {
         return ErrorCode.builder()
-                .status(status)
-                .message(message)
-                .httpStatus(httpStatus)
-                .build();
+            .status(status)
+            .message(message)
+            .httpStatus(httpStatus)
+            .build();
     }
 }

--- a/src/main/java/com/earseo/story/common/exception/StoryError.java
+++ b/src/main/java/com/earseo/story/common/exception/StoryError.java
@@ -10,6 +10,7 @@ public enum StoryError implements ErrorCodeInterface {
     STORY_IMAGE_TOO_MANY("STR001", "이야기의 사진은 3개 이하여야 합니다.", HttpStatus.BAD_REQUEST),
     ITS_NOT_YOU("STR002", "jwt 사용자와 입력 정보가 불일치 합니다.", HttpStatus.CONFLICT),
     STORY_IMAGE_UPLOAD_FAILED("STR003", "이미지 업로드 중 오류가 발생했습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_COORDINATE_RANGE("STR004", "최소 위도/경도는 최대 위도/경도보다 작아야 합니다.", HttpStatus.BAD_REQUEST),
     ;
 
     private final String status;

--- a/src/main/java/com/earseo/story/controller/StoryController.java
+++ b/src/main/java/com/earseo/story/controller/StoryController.java
@@ -223,4 +223,101 @@ public class StoryController {
             storyService.getRectangleMapInfoList(minLongitude, minLatitude, maxLongitude, maxLatitude)
         ));
     }
+
+    @Operation(
+        summary = "특정 지점 반경 내 이야기 스팟 조회",
+        description = """
+            특정 좌표를 중심으로 지정한 반경(미터) 내의 이야기 스팟 목록을 조회합니다.
+            - 중심 좌표와 반경을 입력받습니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = MapSpotInfoList.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                examples = {
+                    @ExampleObject(
+                        name = "반경 범위 오류",
+                        value = """
+                            {
+                                "status": "ARGUMENT_ERROR",
+                                "message": "반경은 1 이상이어야 합니다",
+                                "data": null
+                            }
+                            """
+                    ),
+                    @ExampleObject(
+                        name = "경도 범위 초과",
+                        value = """
+                            {
+                                "status": "ARGUMENT_ERROR",
+                                "message": "경도는 124 이상이어야 합니다",
+                                "data": null
+                            }
+                            """
+                    ),
+                    @ExampleObject(
+                        name = "최대 반경 초과",
+                        value = """
+                            {
+                                "status": "ARGUMENT_ERROR",
+                                "message": "반경은 30000 이하여야 합니다",
+                                "data": null
+                            }
+                            """
+                    )
+                }
+            )
+        )
+    })
+    @GetMapping("/spot/map/circle")
+    public ResponseEntity<BaseResponse<MapSpotInfoList>> getCircleMapInfo(
+        @Parameter(
+            description = "검색 반경 (미터 단위)",
+            required = true,
+            example = "1000",
+            schema = @Schema(minimum = "1", maximum = "30000")
+        )
+        @RequestParam
+        @NotNull(message = "반경은 필수입니다")
+        @DecimalMin(value = "1", message = "반경은 1 이상이어야 합니다")
+        @DecimalMax(value = "30000", message = "반경은 30000 이하여야 합니다")
+        Double meters,
+
+        @Parameter(
+            description = "중심점 경도",
+            required = true,
+            example = "126.9780",
+            schema = @Schema(minimum = "124", maximum = "133")
+        )
+        @RequestParam
+        @NotNull(message = "경도는 필수입니다")
+        @DecimalMin(value = "124", message = "경도는 124 이상이어야 합니다")
+        @DecimalMax(value = "133", message = "경도는 133 이하여야 합니다")
+        Double longitude,
+
+        @Parameter(
+            description = "중심점 위도",
+            required = true,
+            example = "37.5665",
+            schema = @Schema(minimum = "33.0", maximum = "39")
+        )
+        @RequestParam
+        @NotNull(message = "위도는 필수입니다")
+        @DecimalMin(value = "33.0", message = "위도는 33 이상이어야 합니다")
+        @DecimalMax(value = "39", message = "위도는 39 이하여야 합니다")
+        Double latitude
+    ) {
+        return ResponseEntity.ok(BaseResponse.ok(
+            storyService.getCircleMapInfo(meters, longitude, latitude)
+        ));
+    }
+
 }

--- a/src/main/java/com/earseo/story/controller/StoryController.java
+++ b/src/main/java/com/earseo/story/controller/StoryController.java
@@ -1,9 +1,48 @@
 package com.earseo.story.controller;
 
+import com.earseo.story.common.BaseResponse;
+import com.earseo.story.dto.response.SpotTitleListResponse;
+import com.earseo.story.service.StoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/story")
+@RequiredArgsConstructor
 public class StoryController {
+    private final StoryService storyService;
+
+    @Operation(
+        summary = "이야기 스팟의 상위 이야기 제목 목록 조회",
+        description = """
+            특정 이야기 스팟에서 가장 많이 사용된 이야기 제목 목록을 조회합니다.
+            - 이야기 개수의 내림차순으로 정렬됩니다.
+            - 이야기 개수가 동일한 경우 최근에 게시글이 생성된 순으로 정렬됩니다.
+            - 최대 4개의 이야기 제목을 반환합니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "이야기 제목 목록 조회 성공",
+            content = @Content(schema = @Schema(implementation = SpotTitleListResponse.class))
+        )
+    })
+    @GetMapping("/spot/{storySpotId}/name")
+    public ResponseEntity<BaseResponse<SpotTitleListResponse>> getSpotTitleList(
+        @Parameter(description = "이야기 스팟 ID", required = true, example = "1")
+        @PathVariable Long storySpotId
+    ) {
+        return ResponseEntity.ok(BaseResponse.ok(storyService.getSpotTitleList(storySpotId)));
+    }
 }

--- a/src/main/java/com/earseo/story/controller/StoryController.java
+++ b/src/main/java/com/earseo/story/controller/StoryController.java
@@ -1,21 +1,26 @@
 package com.earseo.story.controller;
 
 import com.earseo.story.common.BaseResponse;
+import com.earseo.story.dto.response.LocationSpotBriefInfoResponse;
 import com.earseo.story.dto.response.SpotTitleListResponse;
 import com.earseo.story.service.StoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
+@Validated
 @RestController
 @RequestMapping("/api/story")
 @RequiredArgsConstructor
@@ -29,6 +34,7 @@ public class StoryController {
             - 이야기 개수의 내림차순으로 정렬됩니다.
             - 이야기 개수가 동일한 경우 최근에 게시글이 생성된 순으로 정렬됩니다.
             - 최대 4개의 이야기 제목을 반환합니다.
+            - 빈 배열이 반환된다면 없는 이야기 스팟 id로 요청한 것입니다.
             """
     )
     @ApiResponses({
@@ -44,5 +50,77 @@ public class StoryController {
         @PathVariable Long storySpotId
     ) {
         return ResponseEntity.ok(BaseResponse.ok(storyService.getSpotTitleList(storySpotId)));
+    }
+
+    @Operation(
+        summary = "좌표 기반 이야기 스팟 정보 조회",
+        description = """
+            위도/경도 좌표를 기반으로 해당 위치의 이야기 스팟 정보를 조회합니다.
+            - 좌표를 GeoHash로 변환하여 이야기 스팟을 검색합니다.
+            - 스팟이 존재하는 경우, 해당 스팟의 상위 이야기 제목 목록(최대 4개)을 반환합니다.
+            - 스팟이 존재하지 않는 경우, spotId는 null이고 빈 목록을 반환합니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = LocationSpotBriefInfoResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                examples = {
+                    @ExampleObject(
+                        name = "경도 범위 초과",
+                        value = """
+                            {
+                                "status": "ARGUMENT_ERROR",
+                                "message": "경도는 124 이상이어야 합니다",
+                                "data": null
+                            }
+                            """
+                    ),
+                    @ExampleObject(
+                        name = "위도 범위 초과",
+                        value = """
+                            {
+                                "status": "ARGUMENT_ERROR",
+                                "message": "위도는 33 이상이어야 합니다",
+                                "data": null
+                            }
+                            """
+                    ),
+                }
+            )
+        )
+    })
+    @GetMapping("/spot/info/brief")
+    public ResponseEntity<BaseResponse<LocationSpotBriefInfoResponse>> getLocationSpotBriefInfo(
+        @Parameter(
+            description = "경도",
+            required = true,
+            example = "126.9780",
+            schema = @Schema(minimum = "124", maximum = "133")
+        )
+        @NotNull(message = "경도는 필수입니다")
+        @DecimalMin(value = "124", message = "경도는 124 이상이어야 합니다")
+        @DecimalMax(value = "133", message = "경도는 133 이하여야 합니다")
+        @RequestParam Double longitude,
+
+        @Parameter(
+            description = "위도",
+            required = true,
+            example = "37.5665",
+            schema = @Schema(minimum = "33.0", maximum = "39")
+        )
+        @NotNull(message = "위도는 필수입니다")
+        @DecimalMin(value = "33.0", message = "위도는 33 이상이어야 합니다")
+        @DecimalMax(value = "39", message = "위도는 39 이하여야 합니다")
+        @RequestParam Double latitude
+    ) {
+        return ResponseEntity.ok(BaseResponse.ok(storyService.getLocationSpotBriefInfo(longitude, latitude)));
     }
 }

--- a/src/main/java/com/earseo/story/controller/StoryController.java
+++ b/src/main/java/com/earseo/story/controller/StoryController.java
@@ -2,6 +2,7 @@ package com.earseo.story.controller;
 
 import com.earseo.story.common.BaseResponse;
 import com.earseo.story.dto.response.LocationSpotBriefInfoResponse;
+import com.earseo.story.dto.response.MapSpotInfoList;
 import com.earseo.story.dto.response.SpotTitleListResponse;
 import com.earseo.story.service.StoryService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -122,5 +123,104 @@ public class StoryController {
         @RequestParam Double latitude
     ) {
         return ResponseEntity.ok(BaseResponse.ok(storyService.getLocationSpotBriefInfo(longitude, latitude)));
+    }
+
+    @Operation(
+        summary = "지도 사각형 영역 내 이야기 스팟 조회",
+        description = """
+            지도에서 사각형 영역 내의 이야기 스팟 목록을 조회합니다.
+            - 좌측 하단(minLongitude, minLatitude)과 우측 상단(maxLongitude, maxLatitude) 좌표를 받습니다.
+            - 해당 영역 내에 포함된 모든 이야기 스팟의 위치 정보를 반환합니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = MapSpotInfoList.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                examples = {
+                    @ExampleObject(
+                        name = "좌표 범위 오류",
+                        value = """
+                            {
+                                "status": "ARGUMENT_ERROR",
+                                "message": "최소 위도/경도는 최대 위도/경도보다 작아야 합니다.",
+                                "data": null
+                            }
+                            """
+                    ),
+                    @ExampleObject(
+                        name = "경도 범위 초과",
+                        value = """
+                            {
+                                "status": "ARGUMENT_ERROR",
+                                "message": "경도는 124 이상이어야 합니다",
+                                "data": null
+                            }
+                            """
+                    )
+                }
+            )
+        )
+    })
+    @GetMapping("/spot/map/rectangle")
+    public ResponseEntity<BaseResponse<MapSpotInfoList>> getRectangleMapInfoList(
+        @Parameter(
+            description = "사각형 영역의 최소 경도 (좌측 하단)",
+            required = true,
+            example = "126.9000",
+            schema = @Schema(minimum = "124", maximum = "133")
+        )
+        @RequestParam
+        @NotNull(message = "최소 경도는 필수입니다")
+        @DecimalMin(value = "124", message = "경도는 124 이상이어야 합니다")
+        @DecimalMax(value = "133", message = "경도는 133 이하여야 합니다")
+        Double minLongitude,
+
+        @Parameter(
+            description = "사각형 영역의 최소 위도 (좌측 하단)",
+            required = true,
+            example = "37.5000",
+            schema = @Schema(minimum = "33.0", maximum = "39")
+        )
+        @RequestParam
+        @NotNull(message = "최소 위도는 필수입니다")
+        @DecimalMin(value = "33.0", message = "위도는 33 이상이어야 합니다")
+        @DecimalMax(value = "39", message = "위도는 39 이하여야 합니다")
+        Double minLatitude,
+
+        @Parameter(
+            description = "사각형 영역의 최대 경도 (우측 상단)",
+            required = true,
+            example = "127.1000",
+            schema = @Schema(minimum = "124", maximum = "133")
+        )
+        @RequestParam
+        @NotNull(message = "최대 경도는 필수입니다")
+        @DecimalMin(value = "124", message = "경도는 124 이상이어야 합니다")
+        @DecimalMax(value = "133", message = "경도는 133 이하여야 합니다")
+        Double maxLongitude,
+
+        @Parameter(
+            description = "사각형 영역의 최대 위도 (우측 상단)",
+            required = true,
+            example = "37.6000",
+            schema = @Schema(minimum = "33.0", maximum = "39")
+        )
+        @RequestParam
+        @NotNull(message = "최대 위도는 필수입니다")
+        @DecimalMin(value = "33.0", message = "위도는 33 이상이어야 합니다")
+        @DecimalMax(value = "39", message = "위도는 39 이하여야 합니다")
+        Double maxLatitude
+    ) {
+        return ResponseEntity.ok(BaseResponse.ok(
+            storyService.getRectangleMapInfoList(minLongitude, minLatitude, maxLongitude, maxLatitude)
+        ));
     }
 }

--- a/src/main/java/com/earseo/story/controller/StoryController.java
+++ b/src/main/java/com/earseo/story/controller/StoryController.java
@@ -3,6 +3,7 @@ package com.earseo.story.controller;
 import com.earseo.story.common.BaseResponse;
 import com.earseo.story.dto.response.LocationSpotBriefInfoResponse;
 import com.earseo.story.dto.response.MapSpotInfoList;
+import com.earseo.story.dto.response.SearchSpotInfoList;
 import com.earseo.story.dto.response.SpotTitleListResponse;
 import com.earseo.story.service.StoryService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,9 +13,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.validation.constraints.DecimalMax;
-import jakarta.validation.constraints.DecimalMin;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -317,6 +316,161 @@ public class StoryController {
     ) {
         return ResponseEntity.ok(BaseResponse.ok(
             storyService.getCircleMapInfo(meters, longitude, latitude)
+        ));
+    }
+
+    @Operation(
+        summary = "이야기 제목 키워드 검색 (사각 영역)",
+        description = """
+            지정된 사각형 영역 내에서 키워드를 포함하는 이야기 제목을 가진 스팟을 검색합니다.
+            - 각 스팟의 상위 4개 이야기 제목 중 키워드가 포함된 스팟을 반환합니다.
+            - 요청 좌표로부터의 거리를 함께 반환합니다.
+            - 키워드와 매칭된 제목 중 이야기 개수가 가장 많은 제목을 반환합니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = SearchSpotInfoList.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                examples = {
+                    @ExampleObject(
+                        name = "키워드 누락",
+                        value = """
+                            {
+                                "status": "ARGUMENT_ERROR",
+                                "message": "검색 키워드는 필수입니다",
+                                "data": null
+                            }
+                            """
+                    ),
+                    @ExampleObject(
+                        name = "키워드 길이 초과",
+                        value = """
+                            {
+                                "status": "ARGUMENT_ERROR",
+                                "message": "검색 키워드는 20자 이하여야 합니다",
+                                "data": null
+                            }
+                            """
+                    ),
+                    @ExampleObject(
+                        name = "좌표 범위 오류",
+                        value = """
+                            {
+                                "status": "ARGUMENT_ERROR",
+                                "message": "경도는 124 이상이어야 합니다",
+                                "data": null
+                            }
+                            """
+                    )
+                }
+            )
+        )
+    })
+    @GetMapping("/search/title")
+    public ResponseEntity<BaseResponse<SearchSpotInfoList>> searchTitle(
+        @Parameter(
+            description = "검색 키워드",
+            required = true,
+            example = "맛집"
+        )
+        @RequestParam
+        @NotBlank(message = "검색 키워드는 필수입니다")
+        @Size(max = 20, message = "검색 키워드는 20자 이하여야 합니다")
+        String keyword,
+
+        @Parameter(
+            description = "기준 경도",
+            required = true,
+            example = "126.9780",
+            schema = @Schema(minimum = "124", maximum = "133")
+        )
+        @RequestParam
+        @NotNull(message = "경도는 필수입니다")
+        @DecimalMin(value = "124", message = "경도는 124 이상이어야 합니다")
+        @DecimalMax(value = "133", message = "경도는 133 이하여야 합니다")
+        Double longitude,
+
+        @Parameter(
+            description = "기준 위도",
+            required = true,
+            example = "37.5665",
+            schema = @Schema(minimum = "33.0", maximum = "39")
+        )
+        @RequestParam
+        @NotNull(message = "위도는 필수입니다")
+        @DecimalMin(value = "33.0", message = "위도는 33 이상이어야 합니다")
+        @DecimalMax(value = "39", message = "위도는 39 이하여야 합니다")
+        Double latitude,
+
+        @Parameter(
+            description = "사각형 영역의 최소 경도 (좌측 하단)",
+            required = true,
+            example = "126.9000",
+            schema = @Schema(minimum = "124", maximum = "133")
+        )
+        @RequestParam
+        @NotNull(message = "최소 경도는 필수입니다")
+        @DecimalMin(value = "124", message = "경도는 124 이상이어야 합니다")
+        @DecimalMax(value = "133", message = "경도는 133 이하여야 합니다")
+        Double minLongitude,
+
+        @Parameter(
+            description = "사각형 영역의 최소 위도 (좌측 하단)",
+            required = true,
+            example = "37.5000",
+            schema = @Schema(minimum = "33.0", maximum = "39")
+        )
+        @RequestParam
+        @NotNull(message = "최소 위도는 필수입니다")
+        @DecimalMin(value = "33.0", message = "위도는 33 이상이어야 합니다")
+        @DecimalMax(value = "39", message = "위도는 39 이하여야 합니다")
+        Double minLatitude,
+
+        @Parameter(
+            description = "사각형 영역의 최대 경도 (우측 상단)",
+            required = true,
+            example = "127.1000",
+            schema = @Schema(minimum = "124", maximum = "133")
+        )
+        @RequestParam
+        @NotNull(message = "최대 경도는 필수입니다")
+        @DecimalMin(value = "124", message = "경도는 124 이상이어야 합니다")
+        @DecimalMax(value = "133", message = "경도는 133 이하여야 합니다")
+        Double maxLongitude,
+
+        @Parameter(
+            description = "사각형 영역의 최대 위도 (우측 상단)",
+            required = true,
+            example = "37.6000",
+            schema = @Schema(minimum = "33.0", maximum = "39")
+        )
+        @RequestParam
+        @NotNull(message = "최대 위도는 필수입니다")
+        @DecimalMin(value = "33.0", message = "위도는 33 이상이어야 합니다")
+        @DecimalMax(value = "39", message = "위도는 39 이하여야 합니다")
+        Double maxLatitude,
+
+
+        @Parameter(
+            description = "반환할 최대 결과 개수",
+            example = "10",
+            schema = @Schema(minimum = "1", maximum = "100")
+        )
+        @RequestParam(defaultValue = "10")
+        @Min(value = 1, message = "제한 개수는 1 이상이어야 합니다")
+        @Max(value = 100, message = "제한 개수는 100 이하여야 합니다")
+        Integer limit
+    ) {
+        return ResponseEntity.ok(BaseResponse.ok(
+            storyService.searchTitleRectangle(keyword, longitude, latitude, minLongitude, minLatitude, maxLongitude, maxLatitude, limit)
         ));
     }
 

--- a/src/main/java/com/earseo/story/controller/StoryUserController.java
+++ b/src/main/java/com/earseo/story/controller/StoryUserController.java
@@ -1,9 +1,123 @@
 package com.earseo.story.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.earseo.story.common.BaseResponse;
+import com.earseo.story.common.exception.BaseException;
+import com.earseo.story.dto.request.CreateRequest;
+import com.earseo.story.dto.response.CreateResponse;
+import com.earseo.story.service.StoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static com.earseo.story.common.exception.StoryError.STORY_IMAGE_TOO_MANY;
 
 @RestController
 @RequestMapping("/api/user/story")
+@RequiredArgsConstructor
 public class StoryUserController {
+    private final StoryService storyService;
+
+    @Operation(
+        summary = "이야기 생성",
+        description = """
+            사용자가 새로운 이야기를 작성합니다.
+            - 위치 정보(위도/경도)를 기반으로 GeoHash를 생성하여 이야기 스팟에 저장합니다.
+            - 최대 3개의 이미지를 함께 업로드할 수 있습니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "이야기 생성 성공",
+            content = @Content(schema = @Schema(implementation = CreateResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                examples = {
+                    @ExampleObject(
+                        name = "이미지 개수 초과",
+                        value = """
+                            {
+                                "status": "STR001",
+                                "message": "이야기의 사진은 3개 이하여야 합니다.",
+                                "data": null
+                            }
+                            """
+                    ),
+                    @ExampleObject(
+                        name = "이미지 업로드 실패",
+                        value = """
+                            {
+                                "status": "STR003",
+                                "message": "이미지 업로드 중 오류가 발생했습니다.",
+                                "data": null
+                            }
+                            """
+                    ),
+                    @ExampleObject(
+                        name = "유효성 검증 실패",
+                        value = """
+                            {
+                              "status": "ARGUMENT_ERROR",
+                              "message": "경도는 124 이상이어야 합니다",
+                              "data": null
+                            }
+                            """
+                    )
+                }
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "인증 오류",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                examples = @ExampleObject(
+                    name = "사용자 불일치",
+                    value = """
+                        {
+                            "status": "STR002",
+                            "message": "jwt 사용자와 입력 정보가 불일치 합니다.",
+                            "data": null
+                        }
+                        """
+                )
+            )
+        )
+    })
+    @PostMapping(value = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<BaseResponse<CreateResponse>> createStory(
+        @Parameter(description = "사용자 ID", required = true)
+        @RequestHeader("X-USER-ID") Long memberId,
+        @Parameter(
+            description = "이야기 생성 요청 바디",
+            required = true,
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
+        )
+        @Valid @RequestPart CreateRequest body,
+        @Parameter(
+            description = "이야기 이미지 파일 (최대 3개)",
+            required = false,
+            content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
+        )
+        @RequestPart(required = false) List<MultipartFile> images
+    ) {
+        if (images != null && images.size() > 3) throw new BaseException(STORY_IMAGE_TOO_MANY);
+        return ResponseEntity.ok(BaseResponse.ok(storyService.createStory(memberId, body, images)));
+    }
 }

--- a/src/main/java/com/earseo/story/dto/request/CreateRequest.java
+++ b/src/main/java/com/earseo/story/dto/request/CreateRequest.java
@@ -1,0 +1,52 @@
+package com.earseo.story.dto.request;
+
+import com.earseo.story.entity.Locale;
+import com.earseo.story.entity.StoryConcept;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDateTime;
+
+public record CreateRequest(
+    @NotNull(message = "작성자 id는 필수입니다")
+    @Schema(description = "작성자 ID", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
+    Long authorId,
+    @NotNull(message = "작성자 닉네임은 필수입니다")
+    @Schema(description = "작성자 닉네임", example = "이어동", requiredMode = Schema.RequiredMode.REQUIRED)
+    String authorName,
+    @NotNull(message = "작성자 프로필 url은 필수입니다")
+    @Schema(description = "작성자 프로필 이미지 URL", requiredMode = Schema.RequiredMode.REQUIRED)
+    String authorProfileUrl,
+    @NotNull(message = "작성자 프로필 수정일자는 필수입니다")
+    @Schema(description = "작성자 프로필 수정일자", requiredMode = Schema.RequiredMode.REQUIRED)
+    LocalDateTime authorProfileUpdatedAt,
+    @NotNull(message = "위도는 필수입니다")
+    @DecimalMin(value = "33.0", message = "위도는 33 이상이어야 합니다")
+    @DecimalMax(value = "39", message = "위도는 39 이하여야 합니다")
+    @Schema(description = "위도 (latitude)", example = "37.5665", minimum = "33.0", maximum = "39", requiredMode = Schema.RequiredMode.REQUIRED)
+    Double latitude,
+    @NotNull(message = "경도는 필수입니다")
+    @DecimalMin(value = "124", message = "경도는 124 이상이어야 합니다")
+    @DecimalMax(value = "133", message = "경도는 133 이하여야 합니다")
+    @Schema(description = "경도 (longitude)", example = "126.9780", minimum = "124", maximum = "133", requiredMode = Schema.RequiredMode.REQUIRED)
+    Double longitude,
+    @NotNull(message = "이야기 스팟 ID는 필수입니다")
+    @Positive(message = "이야기 스팟 ID는 양수여야 합니다")
+    @Schema(description = "이야기 스팟 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    Long storySpotId,
+    @NotBlank(message = "제목은 필수입니다")
+    @Size(min = 1, max = 30, message = "제목은 1자 이상 30자 이하여야 합니다")
+    @Schema(description = "이야기 제목", example = "골목길 맛집", minLength = 1, maxLength = 30, requiredMode = Schema.RequiredMode.REQUIRED)
+    String title,
+    @NotBlank(message = "내용은 필수입니다")
+    @Size(min = 1, max = 200, message = "내용은 1자 이상 200자 이하여야 합니다")
+    @Schema(description = "이야기 내용", example = "경복궁 근처 맛있는 카페! 강추..!", minLength = 1, maxLength = 200, requiredMode = Schema.RequiredMode.REQUIRED)
+    String content,
+    @NotNull(message = "이야기 컨셉은 필수입니다")
+    @Schema(description = "이야기 컨셉", example = "TIP", requiredMode = Schema.RequiredMode.REQUIRED)
+    StoryConcept storyConcept,
+    @NotNull(message = "locale은 필수입니다")
+    @Schema(description = "언어정보", example = "KO", requiredMode = Schema.RequiredMode.REQUIRED)
+    Locale locale
+) {
+}

--- a/src/main/java/com/earseo/story/dto/response/CreateResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/CreateResponse.java
@@ -1,0 +1,23 @@
+package com.earseo.story.dto.response;
+
+import com.earseo.story.entity.Story;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record CreateResponse(
+    @Schema(description = "이야기 id", example = "1")
+    Long storyId,
+    @Schema(description = "이야기 스팟 id", example = "1")
+    Long storySpotId,
+    @Schema(description = "이야기 생성 시각")
+    LocalDateTime createdAt
+) {
+    public static CreateResponse toDto(Story story) {
+        return new CreateResponse(
+            story.getId(),
+            story.getStorySpot().getId(),
+            story.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/earseo/story/dto/response/LocationSpotBriefInfoResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/LocationSpotBriefInfoResponse.java
@@ -1,0 +1,21 @@
+package com.earseo.story.dto.response;
+
+import com.earseo.story.entity.SpotTitleAggregate;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record LocationSpotBriefInfoResponse(
+    @Schema(description = "좌표의 이야기 스팟 id (null 이면 없는것)")
+    Long spotId,
+    @Schema(description = "이야기 제목 목록 (최대 4개, 이야기 개수 및 최근 수정일 기준 정렬)")
+    List<String> titles
+) {
+    public static LocationSpotBriefInfoResponse toDto(Long spotId, List<SpotTitleAggregate> entityList) {
+        return new LocationSpotBriefInfoResponse(spotId,
+            entityList.stream().map(spotTitleAggregate ->
+                spotTitleAggregate.getStoryTitle().getTitle()
+            ).toList()
+        );
+    }
+}

--- a/src/main/java/com/earseo/story/dto/response/MapSpotInfoList.java
+++ b/src/main/java/com/earseo/story/dto/response/MapSpotInfoList.java
@@ -1,11 +1,16 @@
 package com.earseo.story.dto.response;
 
+import com.earseo.story.entity.StorySpot;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public record MapSpotInfoList(
     @Schema(description = "이야기 스팟 목록")
     List<SpotInfoResponse> storySpots
 ) {
+    public static MapSpotInfoList toDto(List<StorySpot> entities) {
+        return new MapSpotInfoList(entities.stream().map(SpotInfoResponse::toDto).toList());
+    }
 }

--- a/src/main/java/com/earseo/story/dto/response/MapSpotInfoList.java
+++ b/src/main/java/com/earseo/story/dto/response/MapSpotInfoList.java
@@ -1,0 +1,11 @@
+package com.earseo.story.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record MapSpotInfoList(
+    @Schema(description = "이야기 스팟 목록")
+    List<SpotInfoResponse> storySpots
+) {
+}

--- a/src/main/java/com/earseo/story/dto/response/SearchSpotInfoList.java
+++ b/src/main/java/com/earseo/story/dto/response/SearchSpotInfoList.java
@@ -1,0 +1,17 @@
+package com.earseo.story.dto.response;
+
+import com.earseo.story.repository.projectionDto.SearchSpotProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record SearchSpotInfoList(
+    @Schema(description = "이야기 스팟 목록")
+    List<SearchSpotInfoResponse> storySpots
+) {
+    public static SearchSpotInfoList toDto(List<SearchSpotProjection> projections) {
+        return new SearchSpotInfoList(projections.stream()
+            .map(SearchSpotInfoResponse::toDto)
+            .toList());
+    }
+}

--- a/src/main/java/com/earseo/story/dto/response/SearchSpotInfoResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/SearchSpotInfoResponse.java
@@ -1,0 +1,27 @@
+package com.earseo.story.dto.response;
+
+import com.earseo.story.repository.projectionDto.SearchSpotProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SearchSpotInfoResponse(
+    @Schema(description = "경도", example = "126.9780")
+    Double longitude,
+    @Schema(description = "위도", example = "37.5665")
+    Double latitude,
+    @Schema(description = "이야기 스팟 ID", example = "1")
+    Long storySpotId,
+    @Schema(description = "요청한 좌표로부터 거리 (미터)", example = "50.6")
+    Double distance,
+    @Schema(description = "이야기 스팟이 검색 키워드와 유사도 검색으로 검색 대상이 된 이야기 주제 중 이야기가 가장 많은 이야기 주제", example = "맛집")
+    String title
+) {
+    public static SearchSpotInfoResponse toDto(SearchSpotProjection projection) {
+        return new SearchSpotInfoResponse(
+            projection.longitude(),
+            projection.latitude(),
+            projection.storySpotId(),
+            projection.distance(),
+            projection.title()
+        );
+    }
+}

--- a/src/main/java/com/earseo/story/dto/response/SpotInfoResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/SpotInfoResponse.java
@@ -1,0 +1,13 @@
+package com.earseo.story.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SpotInfoResponse(
+    @Schema(description = "경도", example = "126.9780")
+    Double longitude,
+    @Schema(description = "위도", example = "37.5665")
+    Double latitude,
+    @Schema(description = "이야기 스팟 ID", example = "1")
+    Long storySpotId
+) {
+}

--- a/src/main/java/com/earseo/story/dto/response/SpotInfoResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/SpotInfoResponse.java
@@ -1,5 +1,6 @@
 package com.earseo.story.dto.response;
 
+import com.earseo.story.entity.StorySpot;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record SpotInfoResponse(
@@ -10,4 +11,7 @@ public record SpotInfoResponse(
     @Schema(description = "이야기 스팟 ID", example = "1")
     Long storySpotId
 ) {
+    public static SpotInfoResponse toDto(StorySpot entity) {
+        return new SpotInfoResponse(entity.getCenter().getX(), entity.getCenter().getY(), entity.getId());
+    }
 }

--- a/src/main/java/com/earseo/story/dto/response/SpotTitleListResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/SpotTitleListResponse.java
@@ -1,0 +1,19 @@
+package com.earseo.story.dto.response;
+
+import com.earseo.story.entity.SpotTitleAggregate;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record SpotTitleListResponse(
+    @Schema(description = "이야기 제목 목록 (최대 4개, 이야기 개수 및 최근 수정일 기준 정렬)")
+    List<String> titles
+) {
+    public static SpotTitleListResponse toDto(List<SpotTitleAggregate> entityList) {
+        return new SpotTitleListResponse(
+            entityList.stream().map(spotTitleAggregate ->
+                spotTitleAggregate.getStoryTitle().getTitle()
+            ).toList()
+        );
+    }
+}

--- a/src/main/java/com/earseo/story/entity/Locale.java
+++ b/src/main/java/com/earseo/story/entity/Locale.java
@@ -1,0 +1,12 @@
+package com.earseo.story.entity;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum Locale {
+    KO("한국어", "Korean"),
+    EN("영어", "English"),
+    ;
+    private String koName;
+    private String enName;
+}

--- a/src/main/java/com/earseo/story/entity/SpotTitleAggregate.java
+++ b/src/main/java/com/earseo/story/entity/SpotTitleAggregate.java
@@ -44,5 +44,5 @@ public class SpotTitleAggregate {
     private Long storyCount = 0L;
 
     @LastModifiedDate
-    private LocalDateTime lastModifiedDate;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/earseo/story/entity/SpotTitleAggregate.java
+++ b/src/main/java/com/earseo/story/entity/SpotTitleAggregate.java
@@ -1,0 +1,42 @@
+package com.earseo.story.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+    uniqueConstraints = @UniqueConstraint(
+        name = "spot_title_unique_constraint",
+        columnNames = {"story_spot_id", "story_title_id"}
+    ),
+    indexes = {
+        @Index(name = "spot_title_aggregate_spot_idx", columnList = "story_spot_id,story_count DESC"),
+        @Index(name = "spot_title_aggregate_title_idx", columnList = "story_title_id,story_count DESC")
+    })
+public class SpotTitleAggregate {
+    @Id
+    @Column(name = "spot_title_aggregate_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "story_spot_id", nullable = false, updatable = false)
+    private StorySpot storySpot;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "story_title_id", nullable = false, updatable = false)
+    private StoryTitle storyTitle;
+
+    @Builder.Default
+    @Column(name = "story_count", nullable = false)
+    private Long storyCount = 0L;
+}

--- a/src/main/java/com/earseo/story/entity/SpotTitleAggregate.java
+++ b/src/main/java/com/earseo/story/entity/SpotTitleAggregate.java
@@ -5,7 +5,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -39,4 +42,7 @@ public class SpotTitleAggregate {
     @Builder.Default
     @Column(name = "story_count", nullable = false)
     private Long storyCount = 0L;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
 }

--- a/src/main/java/com/earseo/story/entity/Story.java
+++ b/src/main/java/com/earseo/story/entity/Story.java
@@ -5,6 +5,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.geo.Point;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -19,4 +24,21 @@ public class Story {
     @JoinColumn(name = "story_spot_id", nullable = false)
     @ManyToOne
     private StorySpot storySpot;
+    @JoinColumn(name = "story_author_id")
+    @ManyToOne
+    private StoryAuthor storyAuthor;
+    private Point point;
+    private String title;
+    @Column(columnDefinition = "text")
+    private String content;
+    @Enumerated(EnumType.STRING)
+    private Locale locale;
+    @Enumerated(EnumType.STRING)
+    private StoryConcept storyConcept;
+    private Long likeCount; // 리팩토링해서 뺴내야함
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/earseo/story/entity/Story.java
+++ b/src/main/java/com/earseo/story/entity/Story.java
@@ -5,9 +5,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.geo.Point;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -16,6 +17,7 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class Story {
     @Id
     @Column(name = "story_id")
@@ -27,6 +29,7 @@ public class Story {
     @JoinColumn(name = "story_author_id")
     @ManyToOne
     private StoryAuthor storyAuthor;
+    @Column(columnDefinition = "geometry(Point, 4326)")
     private Point point;
     private String title;
     @Column(columnDefinition = "text")
@@ -35,7 +38,8 @@ public class Story {
     private Locale locale;
     @Enumerated(EnumType.STRING)
     private StoryConcept storyConcept;
-    private Long likeCount; // 리팩토링해서 뺴내야함
+    @Builder.Default
+    private Long likeCount = 0L; // 리팩토링해서 뺴내야함
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/earseo/story/entity/Story.java
+++ b/src/main/java/com/earseo/story/entity/Story.java
@@ -31,7 +31,9 @@ public class Story {
     private StoryAuthor storyAuthor;
     @Column(columnDefinition = "geometry(Point, 4326)")
     private Point point;
-    private String title;
+    @JoinColumn(name = "story_title_id", nullable = false)
+    @ManyToOne
+    private StoryTitle storyTitle;
     @Column(columnDefinition = "text")
     private String content;
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/earseo/story/entity/StoryAuthor.java
+++ b/src/main/java/com/earseo/story/entity/StoryAuthor.java
@@ -1,11 +1,12 @@
 package com.earseo.story.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.geo.Point;
 
 import java.time.LocalDateTime;
 
@@ -17,9 +18,16 @@ import java.time.LocalDateTime;
 public class StoryAuthor {
     @Id
     @Column(name = "story_author_id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String nickname;
     private String profileUrl;
+    @Column(nullable = false)
     private LocalDateTime updatedAt;
+
+    public StoryAuthor updateAuthor(String nickname, String profileUrl, LocalDateTime updatedAt) {
+        this.nickname = nickname;
+        this.profileUrl = profileUrl;
+        this.updatedAt = updatedAt;
+        return this;
+    }
 }

--- a/src/main/java/com/earseo/story/entity/StoryAuthor.java
+++ b/src/main/java/com/earseo/story/entity/StoryAuthor.java
@@ -5,9 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.geo.Point;
-import org.springframework.data.geo.Polygon;
 
 import java.time.LocalDateTime;
 
@@ -16,15 +14,12 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class StorySpot {
+public class StoryAuthor {
     @Id
-    @Column(name = "story_spot_id")
+    @Column(name = "story_author_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private Point center;
-    @Column(columnDefinition = "varchar(12)")
-    private String geohash;
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime createdAt;
+    private String nickname;
+    private String profileUrl;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/earseo/story/entity/StoryConcept.java
+++ b/src/main/java/com/earseo/story/entity/StoryConcept.java
@@ -1,0 +1,15 @@
+package com.earseo.story.entity;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum StoryConcept {
+    TIP("꿀팁","Tip"),
+    EXPERIENCE("경험담","Experience"),
+    CULTURE("문화","Culture"),
+    HISTORY("역사","History"),
+    ETC("역사","Etc"),
+    ;
+    private final String koName;
+    private final String enName;
+}

--- a/src/main/java/com/earseo/story/entity/StoryConcept.java
+++ b/src/main/java/com/earseo/story/entity/StoryConcept.java
@@ -4,11 +4,11 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum StoryConcept {
-    TIP("꿀팁","Tip"),
-    EXPERIENCE("경험담","Experience"),
-    CULTURE("문화","Culture"),
-    HISTORY("역사","History"),
-    ETC("역사","Etc"),
+    TIP("꿀팁", "Tip"),
+    EXPERIENCE("경험담", "Experience"),
+    CULTURE("문화", "Culture"),
+    HISTORY("역사", "History"),
+    ETC("기타", "Etc"),
     ;
     private final String koName;
     private final String enName;

--- a/src/main/java/com/earseo/story/entity/StoryImage.java
+++ b/src/main/java/com/earseo/story/entity/StoryImage.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.geo.Point;
-import org.springframework.data.geo.Polygon;
 
 import java.time.LocalDateTime;
 
@@ -16,14 +15,15 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class StorySpot {
+public class StoryImage {
     @Id
-    @Column(name = "story_spot_id")
+    @Column(name = "story_image_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private Point center;
-    @Column(columnDefinition = "varchar(12)")
-    private String geohash;
+    @JoinColumn(name = "story_id", nullable = false)
+    @ManyToOne
+    private Story story;
+    private String imageUrl;
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/earseo/story/entity/StoryImage.java
+++ b/src/main/java/com/earseo/story/entity/StoryImage.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.geo.Point;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class StoryImage {
     @Id
     @Column(name = "story_image_id")
@@ -23,6 +24,7 @@ public class StoryImage {
     @JoinColumn(name = "story_id", nullable = false)
     @ManyToOne
     private Story story;
+    @Column(nullable = false, updatable = false)
     private String imageUrl;
     @CreatedDate
     @Column(updatable = false)

--- a/src/main/java/com/earseo/story/entity/StorySpot.java
+++ b/src/main/java/com/earseo/story/entity/StorySpot.java
@@ -5,9 +5,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.geo.Point;
-import org.springframework.data.geo.Polygon;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -16,13 +16,15 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class StorySpot {
     @Id
     @Column(name = "story_spot_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Column(columnDefinition = "geometry(Point, 4326)", nullable = false, updatable = false)
     private Point center;
-    @Column(columnDefinition = "varchar(12)")
+    @Column(columnDefinition = "varchar(12)", nullable = false, updatable = false)
     private String geohash;
     @CreatedDate
     @Column(updatable = false)

--- a/src/main/java/com/earseo/story/entity/StorySpotSummary.java
+++ b/src/main/java/com/earseo/story/entity/StorySpotSummary.java
@@ -6,8 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.geo.Point;
-import org.springframework.data.geo.Polygon;
 
 import java.time.LocalDateTime;
 
@@ -16,14 +14,19 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class StorySpot {
+public class StorySpotSummary {
     @Id
-    @Column(name = "story_spot_id")
+    @Column(name = "story_spot_summary_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private Point center;
-    @Column(columnDefinition = "varchar(12)")
-    private String geohash;
+    @JoinColumn(name = "story_spot_id", nullable = false)
+    @ManyToOne
+    private StorySpot storySpot;
+    @Enumerated(EnumType.STRING)
+    private StoryConcept storyConcept;
+    private String docentUrl;
+    @Enumerated(EnumType.STRING)
+    private Locale locale;
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/earseo/story/entity/StorySpotSummary.java
+++ b/src/main/java/com/earseo/story/entity/StorySpotSummary.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class StorySpotSummary {
     @Id
     @Column(name = "story_spot_summary_id")

--- a/src/main/java/com/earseo/story/entity/StoryTitle.java
+++ b/src/main/java/com/earseo/story/entity/StoryTitle.java
@@ -1,0 +1,21 @@
+package com.earseo.story.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class StoryTitle {
+    @Id
+    @Column(name = "story_title_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(unique = true, nullable = false, updatable = false)
+    String title;
+}

--- a/src/main/java/com/earseo/story/repository/SpotTitleAggregateRepository.java
+++ b/src/main/java/com/earseo/story/repository/SpotTitleAggregateRepository.java
@@ -1,6 +1,7 @@
 package com.earseo.story.repository;
 
 import com.earseo.story.entity.SpotTitleAggregate;
+import com.earseo.story.repository.projectionDto.SearchSpotProjection;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -30,4 +31,58 @@ public interface SpotTitleAggregateRepository extends JpaRepository<SpotTitleAgg
         """)
     @EntityGraph(attributePaths = {"storyTitle"})
     List<SpotTitleAggregate> findTop4TitleBySpotId(@Param("storySpotId") Long storySpotId, Pageable pageable);
+
+    @Query(value = """
+        WITH ranked_titles AS (
+            SELECT 
+                sta.story_spot_id,
+                sta.story_count,
+                st.title,
+                ss.center,
+                ROW_NUMBER() OVER (
+                    PARTITION BY sta.story_spot_id 
+                    ORDER BY sta.story_count DESC
+                ) as rank
+            FROM spot_title_aggregate sta
+            JOIN story_spot ss ON sta.story_spot_id = ss.story_spot_id
+            JOIN story_title st ON sta.story_title_id = st.story_title_id
+            WHERE ST_Intersects(
+                ss.center,
+                ST_MakeEnvelope(:minLon, :minLat, :maxLon, :maxLat, 4326)
+            )
+        ),
+        filtered_titles AS (
+            SELECT DISTINCT ON (story_spot_id)
+                story_spot_id,
+                story_count,
+                title,
+                center
+            FROM ranked_titles
+            WHERE rank <= 4
+              AND title ILIKE '%' || :keyword || '%'
+            ORDER BY story_spot_id, story_count DESC
+        )
+        SELECT 
+            story_spot_id,
+            ST_X(center) as longitude,
+            ST_Y(center) as latitude,
+            ST_Distance(
+                center::geography,
+                ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography
+            ) as distance,
+            title
+        FROM filtered_titles
+        ORDER BY distance
+        LIMIT :limit
+        """, nativeQuery = true)
+    List<SearchSpotProjection> searchByTitleKeywordRectangle(
+        @Param("keyword") String keyword,
+        @Param("longitude") Double longitude,
+        @Param("latitude") Double latitude,
+        @Param("minLon") Double minLongitude,
+        @Param("minLat") Double minLatitude,
+        @Param("maxLon") Double maxLongitude,
+        @Param("maxLat") Double maxLatitude,
+        @Param("limit") Integer limit
+    );
 }

--- a/src/main/java/com/earseo/story/repository/SpotTitleAggregateRepository.java
+++ b/src/main/java/com/earseo/story/repository/SpotTitleAggregateRepository.java
@@ -1,10 +1,13 @@
 package com.earseo.story.repository;
 
 import com.earseo.story.entity.SpotTitleAggregate;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface SpotTitleAggregateRepository extends JpaRepository<SpotTitleAggregate, Long> {
     @Modifying
@@ -16,4 +19,12 @@ public interface SpotTitleAggregateRepository extends JpaRepository<SpotTitleAgg
             story_count = spot_title_aggregate.story_count + 1
         """, nativeQuery = true)
     void incrementOrCreate(@Param("story_spot_id") Long storySpotId, @Param("story_title_id") Long storyTitleId);
+
+    @Query("""
+            SELECT s
+            FROM SpotTitleAggregate s
+            WHERE s.storySpot.id = :storySpotId
+            ORDER BY s.storyCount DESC, s.lastModifiedDate DESC
+        """)
+    List<SpotTitleAggregate> findTop4TitleBySpotId(@Param("storySpotId") Long storySpotId, Pageable pageable);
 }

--- a/src/main/java/com/earseo/story/repository/SpotTitleAggregateRepository.java
+++ b/src/main/java/com/earseo/story/repository/SpotTitleAggregateRepository.java
@@ -1,0 +1,19 @@
+package com.earseo.story.repository;
+
+import com.earseo.story.entity.SpotTitleAggregate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SpotTitleAggregateRepository extends JpaRepository<SpotTitleAggregate, Long> {
+    @Modifying
+    @Query(value = """
+        INSERT INTO spot_title_aggregate (story_spot_id, story_title_id, story_count)
+        VALUES (:story_spot_id, :story_title_id, 1)
+        ON CONFLICT ON CONSTRAINT spot_title_unique_constraint
+        DO UPDATE SET
+            story_count = spot_title_aggregate.story_count + 1
+        """, nativeQuery = true)
+    void incrementOrCreate(@Param("story_spot_id") Long storySpotId, @Param("story_title_id") Long storyTitleId);
+}

--- a/src/main/java/com/earseo/story/repository/SpotTitleAggregateRepository.java
+++ b/src/main/java/com/earseo/story/repository/SpotTitleAggregateRepository.java
@@ -2,6 +2,7 @@ package com.earseo.story.repository;
 
 import com.earseo.story.entity.SpotTitleAggregate;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -12,11 +13,12 @@ import java.util.List;
 public interface SpotTitleAggregateRepository extends JpaRepository<SpotTitleAggregate, Long> {
     @Modifying
     @Query(value = """
-        INSERT INTO spot_title_aggregate (story_spot_id, story_title_id, story_count)
-        VALUES (:story_spot_id, :story_title_id, 1)
+        INSERT INTO spot_title_aggregate (story_spot_id, story_title_id, story_count, updated_at)
+        VALUES (:story_spot_id, :story_title_id, 1, CURRENT_TIMESTAMP)
         ON CONFLICT ON CONSTRAINT spot_title_unique_constraint
         DO UPDATE SET
-            story_count = spot_title_aggregate.story_count + 1
+            story_count = spot_title_aggregate.story_count + 1,
+            updated_at = CURRENT_TIMESTAMP
         """, nativeQuery = true)
     void incrementOrCreate(@Param("story_spot_id") Long storySpotId, @Param("story_title_id") Long storyTitleId);
 
@@ -24,7 +26,8 @@ public interface SpotTitleAggregateRepository extends JpaRepository<SpotTitleAgg
             SELECT s
             FROM SpotTitleAggregate s
             WHERE s.storySpot.id = :storySpotId
-            ORDER BY s.storyCount DESC, s.lastModifiedDate DESC
+            ORDER BY s.storyCount DESC, s.updatedAt DESC
         """)
+    @EntityGraph(attributePaths = {"storyTitle"})
     List<SpotTitleAggregate> findTop4TitleBySpotId(@Param("storySpotId") Long storySpotId, Pageable pageable);
 }

--- a/src/main/java/com/earseo/story/repository/StoryAuthorRepository.java
+++ b/src/main/java/com/earseo/story/repository/StoryAuthorRepository.java
@@ -1,0 +1,7 @@
+package com.earseo.story.repository;
+
+import com.earseo.story.entity.StoryAuthor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoryAuthorRepository extends JpaRepository<StoryAuthor, Long> {
+}

--- a/src/main/java/com/earseo/story/repository/StoryImageRepository.java
+++ b/src/main/java/com/earseo/story/repository/StoryImageRepository.java
@@ -1,0 +1,7 @@
+package com.earseo.story.repository;
+
+import com.earseo.story.entity.StoryImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoryImageRepository extends JpaRepository<StoryImage, Long> {
+}

--- a/src/main/java/com/earseo/story/repository/StorySpotRepository.java
+++ b/src/main/java/com/earseo/story/repository/StorySpotRepository.java
@@ -2,9 +2,27 @@ package com.earseo.story.repository;
 
 import com.earseo.story.entity.StorySpot;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface StorySpotRepository extends JpaRepository<StorySpot, Long> {
     Optional<StorySpot> findByGeohash(String geohash);
+
+    @Query(value = """
+        SELECT s.story_spot_id, s.center, s.geohash, s.created_at
+        FROM story_spot s
+        WHERE ST_Intersects(
+            s.center,
+            ST_MakeEnvelope(:minLatitude, :minLongitude, :maxLatitude, :maxLongitude, 4326)
+        )
+        """, nativeQuery = true)
+    List<StorySpot> findByBoundingBox(
+        @Param("minLongitude") Double minLongitude,
+        @Param("minLatitude") Double minLatitude,
+        @Param("maxLongitude") Double maxLongitude,
+        @Param("maxLatitude") Double maxLatitude
+    );
 }

--- a/src/main/java/com/earseo/story/repository/StorySpotRepository.java
+++ b/src/main/java/com/earseo/story/repository/StorySpotRepository.java
@@ -3,5 +3,8 @@ package com.earseo.story.repository;
 import com.earseo.story.entity.StorySpot;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface StorySpotRepository extends JpaRepository<StorySpot, Long> {
+    Optional<StorySpot> findByGeohash(String geohash);
 }

--- a/src/main/java/com/earseo/story/repository/StorySpotRepository.java
+++ b/src/main/java/com/earseo/story/repository/StorySpotRepository.java
@@ -16,7 +16,7 @@ public interface StorySpotRepository extends JpaRepository<StorySpot, Long> {
         FROM story_spot s
         WHERE ST_Intersects(
             s.center,
-            ST_MakeEnvelope(:minLatitude, :minLongitude, :maxLatitude, :maxLongitude, 4326)
+            ST_MakeEnvelope(:minLongitude, :minLatitude, :maxLongitude, :maxLatitude, 4326)
         )
         """, nativeQuery = true)
     List<StorySpot> findByBoundingBox(
@@ -31,7 +31,7 @@ public interface StorySpotRepository extends JpaRepository<StorySpot, Long> {
         FROM story_spot s
         WHERE ST_DWithin(
             s.center::geography,
-            ST_SetSRID(ST_MakePoint(:latitude, :longitude), 4326)::geography,
+            ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography,
             :meters
         )
         """, nativeQuery = true)

--- a/src/main/java/com/earseo/story/repository/StorySpotRepository.java
+++ b/src/main/java/com/earseo/story/repository/StorySpotRepository.java
@@ -25,4 +25,19 @@ public interface StorySpotRepository extends JpaRepository<StorySpot, Long> {
         @Param("maxLongitude") Double maxLongitude,
         @Param("maxLatitude") Double maxLatitude
     );
+
+    @Query(value = """
+        SELECT s.story_spot_id, s.center, s.geohash, s.created_at
+        FROM story_spot s
+        WHERE ST_DWithin(
+            s.center::geography,
+            ST_SetSRID(ST_MakePoint(:latitude, :longitude), 4326)::geography,
+            :meters
+        )
+        """, nativeQuery = true)
+    List<StorySpot> findByRadius(
+        @Param("longitude") Double longitude,
+        @Param("latitude") Double latitude,
+        @Param("meters") Double meters
+    );
 }

--- a/src/main/java/com/earseo/story/repository/StoryTitleRepository.java
+++ b/src/main/java/com/earseo/story/repository/StoryTitleRepository.java
@@ -1,0 +1,10 @@
+package com.earseo.story.repository;
+
+import com.earseo.story.entity.StoryTitle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface StoryTitleRepository extends JpaRepository<StoryTitle, Long> {
+    Optional<StoryTitle> findByTitle(String title);
+}

--- a/src/main/java/com/earseo/story/repository/projectionDto/SearchSpotProjection.java
+++ b/src/main/java/com/earseo/story/repository/projectionDto/SearchSpotProjection.java
@@ -1,0 +1,10 @@
+package com.earseo.story.repository.projectionDto;
+
+public record SearchSpotProjection(
+    Long storySpotId,
+    Double longitude,
+    Double latitude,
+    Double distance,
+    String title
+) {
+}

--- a/src/main/java/com/earseo/story/service/S3Service.java
+++ b/src/main/java/com/earseo/story/service/S3Service.java
@@ -1,0 +1,79 @@
+package com.earseo.story.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+    @Value("${cloud.aws.cloudfront.domain}")
+    private String cloudFrontDomain;
+
+    private final AmazonS3 amazonS3;
+
+    /**
+     * S3에 파일 업로드하고 CloudFront URL 반환
+     */
+    public String uploadFile(MultipartFile file, String directory) {
+        String originalFilename = file.getOriginalFilename();
+        String extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+        String savedFilename = UUID.randomUUID() + extension;
+        String fileKey = directory + "/" + savedFilename;
+        try {
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentLength(file.getSize());
+            metadata.setContentType(file.getContentType());
+            amazonS3.putObject(new PutObjectRequest(bucket, fileKey, file.getInputStream(), metadata));
+            return getCloudFrontUrl(fileKey);
+        } catch (IOException e) {
+            log.error("S3 파일 업로드 실패: {}", e.getMessage());
+            throw new RuntimeException("파일 업로드에 실패했습니다.", e);
+        }
+    }
+
+    /**
+     * S3에서 파일 삭제 (CloudFront URL을 S3 key로 변환)
+     */
+    public void deleteFile(String fileUrl) {
+        try {
+            String fileKey = extractFileKeyFromUrl(fileUrl);
+            amazonS3.deleteObject(bucket, fileKey);
+        } catch (Exception e) {
+            log.error("S3 파일 삭제 실패 {} : {}", fileUrl, e.getMessage());
+        }
+    }
+
+    /**
+     * CloudFront URL 생성
+     */
+    private String getCloudFrontUrl(String fileKey) {
+        return String.format("https://%s/%s", cloudFrontDomain, fileKey);
+    }
+
+    /**
+     * CloudFront URL 또는 S3 URL에서 파일 키 추출
+     */
+    private String extractFileKeyFromUrl(String fileUrl) {
+        // CloudFront URL인 경우
+        if (fileUrl.contains(cloudFrontDomain)) {
+            return fileUrl.substring(fileUrl.indexOf(cloudFrontDomain) + cloudFrontDomain.length() + 1);
+        }
+        // S3 URL인 경우
+        if (fileUrl.contains(bucket)) {
+            return fileUrl.substring(fileUrl.indexOf(bucket) + bucket.length() + 1);
+        }
+        throw new IllegalArgumentException("유효하지 않은 파일 URL입니다: " + fileUrl);
+    }
+}

--- a/src/main/java/com/earseo/story/service/StoryService.java
+++ b/src/main/java/com/earseo/story/service/StoryService.java
@@ -4,14 +4,8 @@ import ch.hsr.geohash.GeoHash;
 import com.earseo.story.common.exception.BaseException;
 import com.earseo.story.dto.request.CreateRequest;
 import com.earseo.story.dto.response.CreateResponse;
-import com.earseo.story.entity.Story;
-import com.earseo.story.entity.StoryAuthor;
-import com.earseo.story.entity.StoryImage;
-import com.earseo.story.entity.StorySpot;
-import com.earseo.story.repository.StoryAuthorRepository;
-import com.earseo.story.repository.StoryImageRepository;
-import com.earseo.story.repository.StoryRepository;
-import com.earseo.story.repository.StorySpotRepository;
+import com.earseo.story.entity.*;
+import com.earseo.story.repository.*;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,6 +38,8 @@ public class StoryService {
     private final StoryRepository storyRepository;
     private final S3Service s3Service;
     private final StoryImageRepository storyImageRepository;
+    private final StoryTitleRepository storyTitleRepository;
+    private final SpotTitleAggregateRepository spotTitleAggregateRepository;
 
     @Transactional
     public CreateResponse createStory(Long memberId, CreateRequest body, List<MultipartFile> images) {
@@ -78,16 +74,27 @@ public class StoryService {
                         .build()
                 )
             );
+        // 이야기 타이틀 조회
+        StoryTitle storyTitle = storyTitleRepository.findByTitle(body.title())
+            .orElseGet(() ->
+                storyTitleRepository.save(
+                    StoryTitle.builder()
+                        .title(body.title())
+                        .build()
+                )
+            );
         // 이야기 저장
         Story story = storyRepository.save(Story.builder()
             .storySpot(geohashedSpot)
             .storyAuthor(storyAuthor)
             .point(centerPoint)
-            .title(body.title())
+            .storyTitle(storyTitle)
             .content(body.content())
             .locale(body.locale())
             .storyConcept(body.storyConcept())
             .build());
+        // 제목 집계 테이블 최신화
+        spotTitleAggregateRepository.incrementOrCreate(geohashedSpot.getId(), storyTitle.getId());
         // 파일 저장
         if (images != null && !images.isEmpty()) {
             List<StoryImage> storyImages = getImageList(images, spotGeoHash, story);

--- a/src/main/java/com/earseo/story/service/StoryService.java
+++ b/src/main/java/com/earseo/story/service/StoryService.java
@@ -4,12 +4,10 @@ import ch.hsr.geohash.GeoHash;
 import ch.hsr.geohash.WGS84Point;
 import com.earseo.story.common.exception.BaseException;
 import com.earseo.story.dto.request.CreateRequest;
-import com.earseo.story.dto.response.CreateResponse;
-import com.earseo.story.dto.response.LocationSpotBriefInfoResponse;
-import com.earseo.story.dto.response.MapSpotInfoList;
-import com.earseo.story.dto.response.SpotTitleListResponse;
+import com.earseo.story.dto.response.*;
 import com.earseo.story.entity.*;
 import com.earseo.story.repository.*;
+import com.earseo.story.repository.projectionDto.SearchSpotProjection;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Coordinate;
@@ -119,7 +117,7 @@ public class StoryService {
     /**
      * Point 생성 메서드
      */
-    private Point createPoint(double latitude, double longitude) {
+    private Point createPoint(double longitude, double latitude) {
         Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(longitude, latitude));
         point.setSRID(SRID_WGS84);
         return point;
@@ -204,5 +202,29 @@ public class StoryService {
     public MapSpotInfoList getCircleMapInfo(Double meters, Double longitude, Double latitude) {
         List<StorySpot> spots = storySpotRepository.findByRadius(longitude, latitude, meters);
         return MapSpotInfoList.toDto(spots);
+    }
+
+    @Transactional(readOnly = true)
+    public SearchSpotInfoList searchTitleRectangle(
+        String keyword,
+        Double longitude, Double latitude,
+        Double minLongitude, Double minLatitude,
+        Double maxLongitude, Double maxLatitude,
+        int limit
+    ) {
+        if (minLongitude >= maxLongitude || minLatitude >= maxLatitude) {
+            throw new BaseException(INVALID_COORDINATE_RANGE);
+        }
+        List<SearchSpotProjection> responses = spotTitleAggregateRepository.searchByTitleKeywordRectangle(
+            keyword,
+            longitude,
+            latitude,
+            minLongitude,
+            minLatitude,
+            maxLongitude,
+            maxLatitude,
+            limit
+        );
+        return SearchSpotInfoList.toDto(responses);
     }
 }

--- a/src/main/java/com/earseo/story/service/StoryService.java
+++ b/src/main/java/com/earseo/story/service/StoryService.java
@@ -4,10 +4,10 @@ import ch.hsr.geohash.GeoHash;
 import com.earseo.story.common.exception.BaseException;
 import com.earseo.story.dto.request.CreateRequest;
 import com.earseo.story.dto.response.CreateResponse;
+import com.earseo.story.dto.response.LocationSpotBriefInfoResponse;
 import com.earseo.story.dto.response.SpotTitleListResponse;
 import com.earseo.story.entity.*;
 import com.earseo.story.repository.*;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Coordinate;
@@ -16,11 +16,13 @@ import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.earseo.story.common.exception.StoryError.ITS_NOT_YOU;
 import static com.earseo.story.common.exception.StoryError.STORY_IMAGE_UPLOAD_FAILED;
@@ -160,5 +162,17 @@ public class StoryService {
 
     public SpotTitleListResponse getSpotTitleList(Long storySpotId) {
         return SpotTitleListResponse.toDto(spotTitleAggregateRepository.findTop4TitleBySpotId(storySpotId, Pageable.ofSize(4)));
+    }
+
+    public LocationSpotBriefInfoResponse getLocationSpotBriefInfo(Double longitude, Double latitude) {
+        String geoHash = getGeoHash(longitude, latitude);
+        Optional<StorySpot> storySpot = storySpotRepository.findByGeohash(geoHash);
+        if (storySpot.isEmpty()) {
+            return LocationSpotBriefInfoResponse.toDto(null, List.of());
+        }
+        return LocationSpotBriefInfoResponse.toDto(
+            storySpot.get().getId(),
+            spotTitleAggregateRepository.findTop4TitleBySpotId(storySpot.get().getId(), Pageable.ofSize(4))
+        );
     }
 }

--- a/src/main/java/com/earseo/story/service/StoryService.java
+++ b/src/main/java/com/earseo/story/service/StoryService.java
@@ -1,7 +1,151 @@
 package com.earseo.story.service;
 
+import ch.hsr.geohash.GeoHash;
+import com.earseo.story.common.exception.BaseException;
+import com.earseo.story.dto.request.CreateRequest;
+import com.earseo.story.dto.response.CreateResponse;
+import com.earseo.story.entity.Story;
+import com.earseo.story.entity.StoryAuthor;
+import com.earseo.story.entity.StoryImage;
+import com.earseo.story.entity.StorySpot;
+import com.earseo.story.repository.StoryAuthorRepository;
+import com.earseo.story.repository.StoryImageRepository;
+import com.earseo.story.repository.StoryRepository;
+import com.earseo.story.repository.StorySpotRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static com.earseo.story.common.exception.StoryError.ITS_NOT_YOU;
+import static com.earseo.story.common.exception.StoryError.STORY_IMAGE_UPLOAD_FAILED;
+
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class StoryService {
+    private static final int GEOHASH_PRECISION = 9;
+    private static final int SRID_WGS84 = 4326;
+    private static final GeometryFactory GEOMETRY_FACTORY =
+        new GeometryFactory(new PrecisionModel(), SRID_WGS84);
+    private static final String STORY_S3_PATH_FORMAT = "story/%s/%d";
+
+    private final StorySpotRepository storySpotRepository;
+    private final StoryAuthorRepository storyAuthorRepository;
+    private final StoryRepository storyRepository;
+    private final S3Service s3Service;
+    private final StoryImageRepository storyImageRepository;
+
+    @Transactional
+    public CreateResponse createStory(Long memberId, CreateRequest body, List<MultipartFile> images) {
+        // 사용자 검증
+        if (!memberId.equals(body.authorId())) throw new BaseException(ITS_NOT_YOU);
+        StoryAuthor storyAuthor = storyAuthorRepository.findById(body.authorId())
+            .orElseGet(() ->
+                storyAuthorRepository.save(
+                    StoryAuthor.builder()
+                        .id(body.authorId())
+                        .nickname(body.authorName())
+                        .profileUrl(body.authorProfileUrl())
+                        .updatedAt(body.authorProfileUpdatedAt())
+                        .build()
+                )
+            );
+        // 서버의 정보보다 새로운 정보가 있고, 실제로 변경사항이 있을 때만 업데이트
+        if (storyAuthor.getUpdatedAt().isBefore(body.authorProfileUpdatedAt()) &&
+            (!Objects.equals(storyAuthor.getNickname(), body.authorName()) ||
+             !Objects.equals(storyAuthor.getProfileUrl(), body.authorProfileUrl()))) {
+            storyAuthor.updateAuthor(body.authorName(), body.authorProfileUrl(), body.authorProfileUpdatedAt());
+        }
+        // GeoHash 처리
+        String spotGeoHash = getGeoHash(body.longitude(), body.latitude());
+        Point centerPoint = createPoint(body.longitude(), body.latitude());
+        StorySpot geohashedSpot = storySpotRepository.findByGeohash(spotGeoHash)
+            .orElseGet(() ->
+                storySpotRepository.save(
+                    StorySpot.builder()
+                        .geohash(spotGeoHash)
+                        .center(centerPoint)
+                        .build()
+                )
+            );
+        // 이야기 저장
+        Story story = storyRepository.save(Story.builder()
+            .storySpot(geohashedSpot)
+            .storyAuthor(storyAuthor)
+            .point(centerPoint)
+            .title(body.title())
+            .content(body.content())
+            .locale(body.locale())
+            .storyConcept(body.storyConcept())
+            .build());
+        // 파일 저장
+        if (images != null && !images.isEmpty()) {
+            List<StoryImage> storyImages = getImageList(images, spotGeoHash, story);
+            storyImageRepository.saveAll(storyImages);
+        }
+        return CreateResponse.toDto(story);
+    }
+
+    /**
+     * Geohash 값 계산 메서드
+     */
+    private static String getGeoHash(double longitude, double latitude) {
+        return GeoHash.withCharacterPrecision(latitude, longitude, GEOHASH_PRECISION).toBase32();
+    }
+
+    /**
+     * Point 생성 메서드
+     */
+    private Point createPoint(double latitude, double longitude) {
+        Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(longitude, latitude));
+        point.setSRID(SRID_WGS84);
+        return point;
+    }
+
+    /**
+     * 이미지 업로드, StoryImage 엔티티 생성 메서드
+     */
+    private List<StoryImage> getImageList(List<MultipartFile> images, String spotGeoHash, Story story) {
+        List<StoryImage> storyImages = new ArrayList<>();
+        for (MultipartFile image : images) {
+            if (image.isEmpty()) {
+                continue;
+            }
+            try {
+                // S3에 파일 업로드
+                String imageUrl = s3Service.uploadFile(image, String.format(STORY_S3_PATH_FORMAT, spotGeoHash, story.getId()));
+                // StoryImage 엔티티 생성
+                StoryImage storyImage = StoryImage.builder()
+                    .story(story)
+                    .imageUrl(imageUrl)
+                    .build();
+                storyImages.add(storyImage);
+            } catch (Exception e) {
+                // 업로드 실패 시 이미 업로드된 이미지들 롤백
+                rollbackUploadedImages(storyImages);
+                throw new BaseException(STORY_IMAGE_UPLOAD_FAILED);
+            }
+        }
+        return storyImages;
+    }
+
+    private void rollbackUploadedImages(List<StoryImage> uploadedImages) {
+        for (StoryImage storyImage : uploadedImages) {
+            try {
+                s3Service.deleteFile(storyImage.getImageUrl());
+            } catch (Exception e) {
+                log.error("이미지 업로드 롤백 실패", e);
+            }
+        }
+    }
 }

--- a/src/main/java/com/earseo/story/service/StoryService.java
+++ b/src/main/java/com/earseo/story/service/StoryService.java
@@ -4,7 +4,10 @@ import ch.hsr.geohash.GeoHash;
 import ch.hsr.geohash.WGS84Point;
 import com.earseo.story.common.exception.BaseException;
 import com.earseo.story.dto.request.CreateRequest;
-import com.earseo.story.dto.response.*;
+import com.earseo.story.dto.response.CreateResponse;
+import com.earseo.story.dto.response.LocationSpotBriefInfoResponse;
+import com.earseo.story.dto.response.MapSpotInfoList;
+import com.earseo.story.dto.response.SpotTitleListResponse;
 import com.earseo.story.entity.*;
 import com.earseo.story.repository.*;
 import lombok.RequiredArgsConstructor;
@@ -195,15 +198,11 @@ public class StoryService {
         List<StorySpot> spots = storySpotRepository.findByBoundingBox(
             minLongitude, minLatitude, maxLongitude, maxLatitude
         );
+        return MapSpotInfoList.toDto(spots);
+    }
 
-        List<SpotInfoResponse> responses = spots.stream()
-            .map(spot -> new SpotInfoResponse(
-                spot.getCenter().getX(),
-                spot.getCenter().getY(),
-                spot.getId()
-            ))
-            .toList();
-
-        return new MapSpotInfoList(responses);
+    public MapSpotInfoList getCircleMapInfo(Double meters, Double longitude, Double latitude) {
+        List<StorySpot> spots = storySpotRepository.findByRadius(longitude, latitude, meters);
+        return MapSpotInfoList.toDto(spots);
     }
 }

--- a/src/main/java/com/earseo/story/service/StoryService.java
+++ b/src/main/java/com/earseo/story/service/StoryService.java
@@ -4,6 +4,7 @@ import ch.hsr.geohash.GeoHash;
 import com.earseo.story.common.exception.BaseException;
 import com.earseo.story.dto.request.CreateRequest;
 import com.earseo.story.dto.response.CreateResponse;
+import com.earseo.story.dto.response.SpotTitleListResponse;
 import com.earseo.story.entity.*;
 import com.earseo.story.repository.*;
 import jakarta.transaction.Transactional;
@@ -13,6 +14,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -154,5 +156,9 @@ public class StoryService {
                 log.error("이미지 업로드 롤백 실패", e);
             }
         }
+    }
+
+    public SpotTitleListResponse getSpotTitleList(Long storySpotId) {
+        return SpotTitleListResponse.toDto(spotTitleAggregateRepository.findTop4TitleBySpotId(storySpotId, Pageable.ofSize(4)));
     }
 }

--- a/src/main/java/com/earseo/story/service/StoryService.java
+++ b/src/main/java/com/earseo/story/service/StoryService.java
@@ -1,11 +1,10 @@
 package com.earseo.story.service;
 
 import ch.hsr.geohash.GeoHash;
+import ch.hsr.geohash.WGS84Point;
 import com.earseo.story.common.exception.BaseException;
 import com.earseo.story.dto.request.CreateRequest;
-import com.earseo.story.dto.response.CreateResponse;
-import com.earseo.story.dto.response.LocationSpotBriefInfoResponse;
-import com.earseo.story.dto.response.SpotTitleListResponse;
+import com.earseo.story.dto.response.*;
 import com.earseo.story.entity.*;
 import com.earseo.story.repository.*;
 import lombok.RequiredArgsConstructor;
@@ -24,8 +23,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static com.earseo.story.common.exception.StoryError.ITS_NOT_YOU;
-import static com.earseo.story.common.exception.StoryError.STORY_IMAGE_UPLOAD_FAILED;
+import static com.earseo.story.common.exception.StoryError.*;
 
 @Slf4j
 @Service
@@ -68,7 +66,8 @@ public class StoryService {
         }
         // GeoHash 처리
         String spotGeoHash = getGeoHash(body.longitude(), body.latitude());
-        Point centerPoint = createPoint(body.longitude(), body.latitude());
+        Point centerPoint = getGeohashCenterPoint(body.longitude(), body.latitude());
+        Point storyPoint = createPoint(body.longitude(), body.latitude());
         StorySpot geohashedSpot = storySpotRepository.findByGeohash(spotGeoHash)
             .orElseGet(() ->
                 storySpotRepository.save(
@@ -91,7 +90,7 @@ public class StoryService {
         Story story = storyRepository.save(Story.builder()
             .storySpot(geohashedSpot)
             .storyAuthor(storyAuthor)
-            .point(centerPoint)
+            .point(storyPoint)
             .storyTitle(storyTitle)
             .content(body.content())
             .locale(body.locale())
@@ -121,6 +120,15 @@ public class StoryService {
         Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(longitude, latitude));
         point.setSRID(SRID_WGS84);
         return point;
+    }
+
+    /**
+     * Geohash 중심 좌표 계산 메서드
+     */
+    private Point getGeohashCenterPoint(double longitude, double latitude) {
+        GeoHash geoHashObject = GeoHash.withCharacterPrecision(latitude, longitude, GEOHASH_PRECISION);
+        WGS84Point centerWGS84 = geoHashObject.getBoundingBoxCenter();
+        return createPoint(centerWGS84.getLongitude(), centerWGS84.getLatitude());
     }
 
     /**
@@ -174,5 +182,28 @@ public class StoryService {
             storySpot.get().getId(),
             spotTitleAggregateRepository.findTop4TitleBySpotId(storySpot.get().getId(), Pageable.ofSize(4))
         );
+    }
+
+    public MapSpotInfoList getRectangleMapInfoList(
+        Double minLongitude, Double minLatitude,
+        Double maxLongitude, Double maxLatitude
+    ) {
+        if (minLongitude >= maxLongitude || minLatitude >= maxLatitude) {
+            throw new BaseException(INVALID_COORDINATE_RANGE);
+        }
+
+        List<StorySpot> spots = storySpotRepository.findByBoundingBox(
+            minLongitude, minLatitude, maxLongitude, maxLatitude
+        );
+
+        List<SpotInfoResponse> responses = spots.stream()
+            .map(spot -> new SpotInfoResponse(
+                spot.getCenter().getX(),
+                spot.getCenter().getY(),
+                spot.getId()
+            ))
+            .toList();
+
+        return new MapSpotInfoList(responses);
     }
 }

--- a/src/main/java/com/earseo/story/service/StorySpotService.java
+++ b/src/main/java/com/earseo/story/service/StorySpotService.java
@@ -1,7 +1,0 @@
-package com.earseo.story.service;
-
-import org.springframework.stereotype.Service;
-
-@Service
-public class StorySpotService {
-}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -82,3 +82,14 @@ management:
 logging:
   level:
     org.hibernate.SQL: ${LOGGING_LEVEL_ORG_HIBERNATE_SQL:debug}
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_CREDENTAIL_ACCESS_KEY:acess_key}
+      secret-key: ${AWS_CREDENTAIL_SECRET_KEY:secret_key}
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: ${AWS_S#_BUCKET:example-bucket}
+    cloudfront:
+      domain: ${AWS_CLOUDFRONT_DOMAIN:cdn.example.com}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -63,7 +63,17 @@ management:
       application: ${spring.application.name}
   tracing:
     enabled: false
-
 logging:
   level:
     org.hibernate.SQL: ${LOGGING_LEVEL_ORG_HIBERNATE_SQL:debug}
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_CREDENTAIL_ACCESS_KEY:acess_key}
+      secret-key: ${AWS_CREDENTAIL_SECRET_KEY:secret_key}
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: ${AWS_S#_BUCKET:example-bucket}
+    cloudfront:
+      domain: ${AWS_CLOUDFRONT_DOMAIN:cdn.example.com}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:15432}/${DB_NAME:postgres}
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:15432}/${DB_NAME:story}
     username: ${DB_USERNAME:postgres}
     password: ${DB_PASSWORD:postgres}
 

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -61,3 +61,14 @@ management:
 logging:
   level:
     org.hibernate.SQL: ${LOGGING_LEVEL_ORG_HIBERNATE_SQL:debug}
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_CREDENTAIL_ACCESS_KEY:acess_key}
+      secret-key: ${AWS_CREDENTAIL_SECRET_KEY:secret_key}
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: ${AWS_S#_BUCKET:example-bucket}
+    cloudfront:
+      domain: ${AWS_CLOUDFRONT_DOMAIN:cdn.example.com}

--- a/src/test/java/com/earseo/story/service/StoryCreateTest.java
+++ b/src/test/java/com/earseo/story/service/StoryCreateTest.java
@@ -4,10 +4,7 @@ import com.earseo.story.common.exception.BaseException;
 import com.earseo.story.dto.request.CreateRequest;
 import com.earseo.story.dto.response.CreateResponse;
 import com.earseo.story.entity.*;
-import com.earseo.story.repository.StoryAuthorRepository;
-import com.earseo.story.repository.StoryImageRepository;
-import com.earseo.story.repository.StoryRepository;
-import com.earseo.story.repository.StorySpotRepository;
+import com.earseo.story.repository.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,6 +52,9 @@ class StoryCreateTest {
     private StoryImageRepository storyImageRepository;
 
     @Mock
+    private StoryTitleRepository storyTitleRepository;
+
+    @Mock
     private S3Service s3Service;
 
     @Test
@@ -68,7 +68,8 @@ class StoryCreateTest {
 
         StoryAuthor savedAuthor = createStoryAuthor(1L, "이어동", now);
         StorySpot savedSpot = createStorySpot(1L, "wydm6djcm");
-        Story savedStory = createStory(1L, savedAuthor, savedSpot, now);
+        StoryTitle storyTitle = createStoryTitle(1L, "골목길 맛집");
+        Story savedStory = createStory(1L, savedAuthor, savedSpot, storyTitle, now);
 
         given(storyAuthorRepository.findById(1L)).willReturn(Optional.empty());
         given(storyAuthorRepository.save(any(StoryAuthor.class))).willReturn(savedAuthor);
@@ -104,7 +105,8 @@ class StoryCreateTest {
 
         StoryAuthor existingAuthor = createStoryAuthor(1L, "이어동", oldTime);
         StorySpot existingSpot = createStorySpot(1L, "wydm6djcm");
-        Story savedStory = createStory(1L, existingAuthor, existingSpot, now);
+        StoryTitle storyTitle = createStoryTitle(1L, "골목길 맛집");
+        Story savedStory = createStory(1L, existingAuthor, existingSpot, storyTitle, now);
 
         given(storyAuthorRepository.findById(1L)).willReturn(Optional.of(existingAuthor));
         given(storySpotRepository.findByGeohash(anyString())).willReturn(Optional.of(existingSpot));
@@ -150,7 +152,8 @@ class StoryCreateTest {
 
         StoryAuthor existingAuthor = createStoryAuthor(1L, "이어동", oldTime);
         StorySpot existingSpot = createStorySpot(1L, "wydm6djcm");
-        Story savedStory = createStory(1L, existingAuthor, existingSpot, newTime);
+        StoryTitle storyTitle = createStoryTitle(1L, "골목길 맛집");
+        Story savedStory = createStory(1L, existingAuthor, existingSpot, storyTitle, newTime);
 
         given(storyAuthorRepository.findById(1L)).willReturn(Optional.of(existingAuthor));
         given(storySpotRepository.findByGeohash(anyString())).willReturn(Optional.of(existingSpot));
@@ -186,7 +189,8 @@ class StoryCreateTest {
 
         StoryAuthor savedAuthor = createStoryAuthor(1L, "이어동", now);
         StorySpot savedSpot = createStorySpot(1L, "wydm6djcm");
-        Story savedStory = createStory(1L, savedAuthor, savedSpot, now);
+        StoryTitle storyTitle = createStoryTitle(1L, "골목길 맛집");
+        Story savedStory = createStory(1L, savedAuthor, savedSpot, storyTitle, now);
 
         given(storyAuthorRepository.findById(1L)).willReturn(Optional.of(savedAuthor));
         given(storySpotRepository.findByGeohash(anyString())).willReturn(Optional.of(savedSpot));
@@ -241,7 +245,8 @@ class StoryCreateTest {
 
         StoryAuthor savedAuthor = createStoryAuthor(1L, "이어동", now);
         StorySpot savedSpot = createStorySpot(1L, "wydm6djcm");
-        Story savedStory = createStory(1L, savedAuthor, savedSpot, now);
+        StoryTitle storyTitle = createStoryTitle(1L, "골목길 맛집");
+        Story savedStory = createStory(1L, savedAuthor, savedSpot, storyTitle, now);
 
         given(storyAuthorRepository.findById(1L)).willReturn(Optional.of(savedAuthor));
         given(storySpotRepository.findByGeohash(anyString())).willReturn(Optional.of(savedSpot));
@@ -275,6 +280,10 @@ class StoryCreateTest {
         );
     }
 
+    private StoryTitle createStoryTitle(Long id, String title) {
+        return new StoryTitle(id, title);
+    }
+
     private StoryAuthor createStoryAuthor(Long id, String nickname, LocalDateTime updatedAt) {
         return StoryAuthor.builder()
             .id(id)
@@ -296,7 +305,7 @@ class StoryCreateTest {
         return spot;
     }
 
-    private Story createStory(Long id, StoryAuthor author, StorySpot spot, LocalDateTime createdAt) {
+    private Story createStory(Long id, StoryAuthor author, StorySpot spot, StoryTitle storyTitle, LocalDateTime createdAt) {
         Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(126.9780, 37.5665));
         point.setSRID(4326);
 
@@ -304,7 +313,7 @@ class StoryCreateTest {
             .storyAuthor(author)
             .storySpot(spot)
             .point(point)
-            .title("골목길 맛집")
+            .storyTitle(storyTitle)
             .content("경복궁 근처 맛있는 카페! 강추..!")
             .locale(Locale.KO)
             .storyConcept(StoryConcept.TIP)

--- a/src/test/java/com/earseo/story/service/StoryCreateTest.java
+++ b/src/test/java/com/earseo/story/service/StoryCreateTest.java
@@ -1,0 +1,325 @@
+package com.earseo.story.service;
+
+import com.earseo.story.common.exception.BaseException;
+import com.earseo.story.dto.request.CreateRequest;
+import com.earseo.story.dto.response.CreateResponse;
+import com.earseo.story.entity.*;
+import com.earseo.story.repository.StoryAuthorRepository;
+import com.earseo.story.repository.StoryImageRepository;
+import com.earseo.story.repository.StoryRepository;
+import com.earseo.story.repository.StorySpotRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("이야기 생성을 할 때 ")
+class StoryCreateTest {
+
+    private static final GeometryFactory GEOMETRY_FACTORY =
+        new GeometryFactory(new PrecisionModel(), 4326);
+
+    @InjectMocks
+    private StoryService storyService;
+
+    @Mock
+    private StoryRepository storyRepository;
+
+    @Mock
+    private StoryAuthorRepository storyAuthorRepository;
+
+    @Mock
+    private StorySpotRepository storySpotRepository;
+
+    @Mock
+    private StoryImageRepository storyImageRepository;
+
+    @Mock
+    private S3Service s3Service;
+
+    @Test
+    @DisplayName("신규 작성자와 신규 스팟으로 이야기 생성 성공")
+    void createStory_WithNewAuthorAndNewSpot_Success() {
+        // Given
+        Long memberId = 1L;
+        LocalDateTime now = LocalDateTime.now();
+        CreateRequest request = createRequest(1L, now);
+        List<MultipartFile> images = new ArrayList<>();
+
+        StoryAuthor savedAuthor = createStoryAuthor(1L, "이어동", now);
+        StorySpot savedSpot = createStorySpot(1L, "wydm6djcm");
+        Story savedStory = createStory(1L, savedAuthor, savedSpot, now);
+
+        given(storyAuthorRepository.findById(1L)).willReturn(Optional.empty());
+        given(storyAuthorRepository.save(any(StoryAuthor.class))).willReturn(savedAuthor);
+        given(storySpotRepository.findByGeohash(anyString())).willReturn(Optional.empty());
+        given(storySpotRepository.save(any(StorySpot.class))).willReturn(savedSpot);
+        given(storyRepository.save(any(Story.class))).willReturn(savedStory);
+
+        // When
+        CreateResponse response = storyService.createStory(memberId, request, images);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.storyId()).isEqualTo(1L);
+        assertThat(response.storySpotId()).isEqualTo(1L);
+        assertThat(response.createdAt()).isEqualTo(now);
+
+        verify(storyAuthorRepository, times(1)).findById(1L);
+        verify(storyAuthorRepository, times(1)).save(any(StoryAuthor.class));
+        verify(storySpotRepository, times(1)).findByGeohash(anyString());
+        verify(storySpotRepository, times(1)).save(any(StorySpot.class));
+        verify(storyRepository, times(1)).save(any(Story.class));
+    }
+
+    @Test
+    @DisplayName("기존 작성자와 기존 스팟으로 이야기 생성 성공")
+    void createStory_WithExistingAuthorAndSpot_Success() {
+        // Given
+        Long memberId = 1L;
+        LocalDateTime oldTime = LocalDateTime.now().minusDays(1);
+        LocalDateTime now = LocalDateTime.now();
+        CreateRequest request = createRequest(1L, oldTime);
+        List<MultipartFile> images = new ArrayList<>();
+
+        StoryAuthor existingAuthor = createStoryAuthor(1L, "이어동", oldTime);
+        StorySpot existingSpot = createStorySpot(1L, "wydm6djcm");
+        Story savedStory = createStory(1L, existingAuthor, existingSpot, now);
+
+        given(storyAuthorRepository.findById(1L)).willReturn(Optional.of(existingAuthor));
+        given(storySpotRepository.findByGeohash(anyString())).willReturn(Optional.of(existingSpot));
+        given(storyRepository.save(any(Story.class))).willReturn(savedStory);
+
+        // When
+        CreateResponse response = storyService.createStory(memberId, request, images);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.storyId()).isEqualTo(1L);
+        assertThat(response.storySpotId()).isEqualTo(1L);
+
+        verify(storyAuthorRepository, times(1)).findById(1L);
+        verify(storyAuthorRepository, never()).save(any(StoryAuthor.class));
+        verify(storySpotRepository, times(1)).findByGeohash(anyString());
+        verify(storySpotRepository, never()).save(any(StorySpot.class));
+        verify(storyRepository, times(1)).save(any(Story.class));
+    }
+
+    @Test
+    @DisplayName("작성자 프로필 정보 업데이트 후 이야기 생성 성공")
+    void createStory_WithAuthorProfileUpdate_Success() {
+        // Given
+        Long memberId = 1L;
+        LocalDateTime oldTime = LocalDateTime.now().minusDays(2);
+        LocalDateTime newTime = LocalDateTime.now();
+
+        CreateRequest request = new CreateRequest(
+            1L,
+            "이어남",
+            "https://example.com/new-profile.jpg",
+            newTime,
+            37.5665,
+            126.9780,
+            1L,
+            "골목길 맛집",
+            "경복궁 근처 맛있는 카페! 강추..!",
+            StoryConcept.EXPERIENCE,
+            Locale.EN
+        );
+        List<MultipartFile> images = new ArrayList<>();
+
+        StoryAuthor existingAuthor = createStoryAuthor(1L, "이어동", oldTime);
+        StorySpot existingSpot = createStorySpot(1L, "wydm6djcm");
+        Story savedStory = createStory(1L, existingAuthor, existingSpot, newTime);
+
+        given(storyAuthorRepository.findById(1L)).willReturn(Optional.of(existingAuthor));
+        given(storySpotRepository.findByGeohash(anyString())).willReturn(Optional.of(existingSpot));
+        given(storyRepository.save(any(Story.class))).willReturn(savedStory);
+
+        // When
+        CreateResponse response = storyService.createStory(memberId, request, images);
+
+        // Then
+        assertThat(response).isNotNull();
+
+        verify(storyAuthorRepository, times(1)).findById(1L);
+        verify(storyAuthorRepository, never()).save(any(StoryAuthor.class));
+        verify(storyRepository, times(1)).save(any(Story.class));
+
+        assertThat(existingAuthor.getNickname()).isEqualTo("이어남");
+        assertThat(existingAuthor.getProfileUrl()).isEqualTo("https://example.com/new-profile.jpg");
+        assertThat(existingAuthor.getUpdatedAt()).isEqualTo(newTime);
+    }
+
+    @Test
+    @DisplayName("이미지와 함께 이야기 생성 성공")
+    void createStory_WithImages_Success() {
+        // Given
+        Long memberId = 1L;
+        LocalDateTime now = LocalDateTime.now();
+        CreateRequest request = createRequest(1L, now);
+
+        List<MultipartFile> images = List.of(
+            createMockMultipartFile("image1.jpg", "image/jpeg"),
+            createMockMultipartFile("image2.jpg", "image/jpeg")
+        );
+
+        StoryAuthor savedAuthor = createStoryAuthor(1L, "이어동", now);
+        StorySpot savedSpot = createStorySpot(1L, "wydm6djcm");
+        Story savedStory = createStory(1L, savedAuthor, savedSpot, now);
+
+        given(storyAuthorRepository.findById(1L)).willReturn(Optional.of(savedAuthor));
+        given(storySpotRepository.findByGeohash(anyString())).willReturn(Optional.of(savedSpot));
+        given(storyRepository.save(any(Story.class))).willReturn(savedStory);
+        given(s3Service.uploadFile(any(MultipartFile.class), anyString()))
+            .willReturn("https://cdn.example.com/image1.jpg")
+            .willReturn("https://cdn.example.com/image2.jpg");
+
+        // When
+        CreateResponse response = storyService.createStory(memberId, request, images);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.storyId()).isEqualTo(1L);
+
+        verify(s3Service, times(2)).uploadFile(any(MultipartFile.class), anyString());
+        verify(storyImageRepository, times(1)).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("작성자 ID 불일치로 이야기 생성 실패")
+    void createStory_WithMismatchedAuthorId_ThrowsException() {
+        // Given
+        Long memberId = 1L;
+        Long differentAuthorId = 2L;
+
+        CreateRequest request = createRequest(differentAuthorId, LocalDateTime.now());
+        List<MultipartFile> images = new ArrayList<>();
+
+        // When & Then
+        assertThatThrownBy(() -> storyService.createStory(memberId, request, images))
+            .isInstanceOf(BaseException.class)
+            .extracting(exception -> ((BaseException) exception).getErrorCode().getStatus())
+            .isEqualTo("STR002");
+
+        verify(storyAuthorRepository, never()).findById(any());
+        verify(storySpotRepository, never()).findByGeohash(any());
+        verify(storyRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("이미지 업로드 실패 시 예외 발생")
+    void createStory_ImageUploadFails_ThrowsException() {
+        // Given
+        Long memberId = 1L;
+        LocalDateTime now = LocalDateTime.now();
+        CreateRequest request = createRequest(1L, now);
+
+        List<MultipartFile> images = List.of(
+            createMockMultipartFile("image1.jpg", "image/jpeg")
+        );
+
+        StoryAuthor savedAuthor = createStoryAuthor(1L, "이어동", now);
+        StorySpot savedSpot = createStorySpot(1L, "wydm6djcm");
+        Story savedStory = createStory(1L, savedAuthor, savedSpot, now);
+
+        given(storyAuthorRepository.findById(1L)).willReturn(Optional.of(savedAuthor));
+        given(storySpotRepository.findByGeohash(anyString())).willReturn(Optional.of(savedSpot));
+        given(storyRepository.save(any(Story.class))).willReturn(savedStory);
+        given(s3Service.uploadFile(any(MultipartFile.class), anyString()))
+            .willThrow(new RuntimeException("S3 업로드 실패"));
+
+        // When & Then
+        assertThatThrownBy(() -> storyService.createStory(memberId, request, images))
+            .isInstanceOf(BaseException.class)
+            .extracting(exception -> ((BaseException) exception).getErrorCode().getStatus())
+            .isEqualTo("STR003");
+
+        verify(s3Service, times(1)).uploadFile(any(MultipartFile.class), anyString());
+        verify(storyImageRepository, never()).saveAll(anyList());
+    }
+
+    private CreateRequest createRequest(Long authorId, LocalDateTime updatedAt) {
+        return new CreateRequest(
+            authorId,
+            "이어동",
+            "https://example.com/profile.jpg",
+            updatedAt,
+            37.5665,
+            126.9780,
+            1L,
+            "골목길 맛집",
+            "경복궁 근처 맛있는 카페! 강추..!",
+            StoryConcept.TIP,
+            Locale.KO
+        );
+    }
+
+    private StoryAuthor createStoryAuthor(Long id, String nickname, LocalDateTime updatedAt) {
+        return StoryAuthor.builder()
+            .id(id)
+            .nickname(nickname)
+            .profileUrl("https://example.com/profile.jpg")
+            .updatedAt(updatedAt)
+            .build();
+    }
+
+    private StorySpot createStorySpot(Long id, String geohash) {
+        Point center = GEOMETRY_FACTORY.createPoint(new Coordinate(126.9780, 37.5665));
+        center.setSRID(4326);
+
+        StorySpot spot = StorySpot.builder()
+            .geohash(geohash)
+            .center(center)
+            .build();
+        ReflectionTestUtils.setField(spot, "id", id);
+        return spot;
+    }
+
+    private Story createStory(Long id, StoryAuthor author, StorySpot spot, LocalDateTime createdAt) {
+        Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(126.9780, 37.5665));
+        point.setSRID(4326);
+
+        Story story = Story.builder()
+            .storyAuthor(author)
+            .storySpot(spot)
+            .point(point)
+            .title("골목길 맛집")
+            .content("경복궁 근처 맛있는 카페! 강추..!")
+            .locale(Locale.KO)
+            .storyConcept(StoryConcept.TIP)
+            .build();
+        ReflectionTestUtils.setField(story, "id", id);
+        ReflectionTestUtils.setField(story, "createdAt", createdAt);
+        return story;
+    }
+
+    private MockMultipartFile createMockMultipartFile(String filename, String contentType) {
+        return new MockMultipartFile(
+            "images",
+            filename,
+            contentType,
+            "test image content".getBytes()
+        );
+    }
+}

--- a/src/test/java/com/earseo/story/service/StoryCreateTest.java
+++ b/src/test/java/com/earseo/story/service/StoryCreateTest.java
@@ -55,6 +55,9 @@ class StoryCreateTest {
     private StoryTitleRepository storyTitleRepository;
 
     @Mock
+    private SpotTitleAggregateRepository spotTitleAggregateRepository;
+
+    @Mock
     private S3Service s3Service;
 
     @Test
@@ -76,6 +79,7 @@ class StoryCreateTest {
         given(storySpotRepository.findByGeohash(anyString())).willReturn(Optional.empty());
         given(storySpotRepository.save(any(StorySpot.class))).willReturn(savedSpot);
         given(storyRepository.save(any(Story.class))).willReturn(savedStory);
+        given(storyTitleRepository.save(any(StoryTitle.class))).willReturn(storyTitle);
 
         // When
         CreateResponse response = storyService.createStory(memberId, request, images);
@@ -111,6 +115,7 @@ class StoryCreateTest {
         given(storyAuthorRepository.findById(1L)).willReturn(Optional.of(existingAuthor));
         given(storySpotRepository.findByGeohash(anyString())).willReturn(Optional.of(existingSpot));
         given(storyRepository.save(any(Story.class))).willReturn(savedStory);
+        given(storyTitleRepository.save(any(StoryTitle.class))).willReturn(storyTitle);
 
         // When
         CreateResponse response = storyService.createStory(memberId, request, images);
@@ -158,6 +163,7 @@ class StoryCreateTest {
         given(storyAuthorRepository.findById(1L)).willReturn(Optional.of(existingAuthor));
         given(storySpotRepository.findByGeohash(anyString())).willReturn(Optional.of(existingSpot));
         given(storyRepository.save(any(Story.class))).willReturn(savedStory);
+        given(storyTitleRepository.save(any(StoryTitle.class))).willReturn(storyTitle);
 
         // When
         CreateResponse response = storyService.createStory(memberId, request, images);
@@ -195,6 +201,7 @@ class StoryCreateTest {
         given(storyAuthorRepository.findById(1L)).willReturn(Optional.of(savedAuthor));
         given(storySpotRepository.findByGeohash(anyString())).willReturn(Optional.of(savedSpot));
         given(storyRepository.save(any(Story.class))).willReturn(savedStory);
+        given(storyTitleRepository.save(any(StoryTitle.class))).willReturn(storyTitle);
         given(s3Service.uploadFile(any(MultipartFile.class), anyString()))
             .willReturn("https://cdn.example.com/image1.jpg")
             .willReturn("https://cdn.example.com/image2.jpg");
@@ -251,6 +258,7 @@ class StoryCreateTest {
         given(storyAuthorRepository.findById(1L)).willReturn(Optional.of(savedAuthor));
         given(storySpotRepository.findByGeohash(anyString())).willReturn(Optional.of(savedSpot));
         given(storyRepository.save(any(Story.class))).willReturn(savedStory);
+        given(storyTitleRepository.save(any(StoryTitle.class))).willReturn(storyTitle);
         given(s3Service.uploadFile(any(MultipartFile.class), anyString()))
             .willThrow(new RuntimeException("S3 업로드 실패"));
 

--- a/src/test/java/com/earseo/story/service/StoryServiceMapInfoTest.java
+++ b/src/test/java/com/earseo/story/service/StoryServiceMapInfoTest.java
@@ -1,0 +1,147 @@
+package com.earseo.story.service;
+
+import com.earseo.story.common.exception.BaseException;
+import com.earseo.story.dto.response.MapSpotInfoList;
+import com.earseo.story.entity.StorySpot;
+import com.earseo.story.repository.StorySpotRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("지도 조회 테스트")
+class StoryServiceMapInfoTest {
+
+    @Mock
+    private StorySpotRepository storySpotRepository;
+
+    @InjectMocks
+    private StoryService storyService;
+
+    private static final GeometryFactory GEOMETRY_FACTORY =
+        new GeometryFactory(new PrecisionModel(), 4326);
+
+    @Test
+    @DisplayName("사각형 영역 내의 이야기 스팟 목록을 조회한다")
+    void getRectangleMapInfoList_success() {
+        // given
+        Double minLongitude = 126.9;
+        Double minLatitude = 37.5;
+        Double maxLongitude = 127.1;
+        Double maxLatitude = 37.6;
+
+        StorySpot spot1 = createStorySpot(1L, 126.95, 37.55);
+        StorySpot spot2 = createStorySpot(2L, 127.0, 37.56);
+        StorySpot spot3 = createStorySpot(3L, 127.05, 37.57);
+
+        List<StorySpot> mockSpots = List.of(spot1, spot2, spot3);
+
+        given(storySpotRepository.findByBoundingBox(minLongitude, minLatitude, maxLongitude, maxLatitude))
+            .willReturn(mockSpots);
+
+        // when
+        MapSpotInfoList result = storyService.getRectangleMapInfoList(
+            minLongitude, minLatitude, maxLongitude, maxLatitude
+        );
+
+        // then
+        assertThat(result.storySpots()).hasSize(3);
+        assertThat(result.storySpots().get(0).longitude()).isEqualTo(126.95);
+        assertThat(result.storySpots().get(0).latitude()).isEqualTo(37.55);
+        assertThat(result.storySpots().get(0).storySpotId()).isEqualTo(1L);
+        assertThat(result.storySpots().get(1).longitude()).isEqualTo(127.0);
+        assertThat(result.storySpots().get(1).latitude()).isEqualTo(37.56);
+        assertThat(result.storySpots().get(2).longitude()).isEqualTo(127.05);
+        assertThat(result.storySpots().get(2).latitude()).isEqualTo(37.57);
+        assertThat(result.storySpots().get(2).storySpotId()).isEqualTo(3L);
+
+        then(storySpotRepository).should(times(1))
+            .findByBoundingBox(minLongitude, minLatitude, maxLongitude, maxLatitude);
+    }
+
+    @Test
+    @DisplayName("영역 내에 스팟이 없는 경우 빈 목록을 반환한다")
+    void getRectangleMapInfoList_emptyResult() {
+        // given
+        Double minLongitude = 126.9;
+        Double minLatitude = 37.5;
+        Double maxLongitude = 127.1;
+        Double maxLatitude = 37.6;
+
+        given(storySpotRepository.findByBoundingBox(minLongitude, minLatitude, maxLongitude, maxLatitude))
+            .willReturn(List.of());
+
+        // when
+        MapSpotInfoList result = storyService.getRectangleMapInfoList(
+            minLongitude, minLatitude, maxLongitude, maxLatitude
+        );
+
+        // then
+        assertThat(result.storySpots()).isEmpty();
+        then(storySpotRepository).should(times(1))
+            .findByBoundingBox(minLongitude, minLatitude, maxLongitude, maxLatitude);
+    }
+
+    @Test
+    @DisplayName("최소 경도가 최대 경도보다 크거나 같으면 예외가 발생한다")
+    void getRectangleMapInfoList_invalidLongitudeRange() {
+        // given
+        Double minLongitude = 127.1;
+        Double minLatitude = 37.5;
+        Double maxLongitude = 126.9;
+        Double maxLatitude = 37.6;
+
+        // when & then
+        assertThatThrownBy(() -> storyService.getRectangleMapInfoList(
+            minLongitude, minLatitude, maxLongitude, maxLatitude
+        )).isInstanceOf(BaseException.class);
+
+        then(storySpotRepository).should(never())
+            .findByBoundingBox(anyDouble(), anyDouble(), anyDouble(), anyDouble());
+    }
+
+    @Test
+    @DisplayName("최소 위도가 최대 위도보다 크거나 같으면 예외가 발생한다")
+    void getRectangleMapInfoList_invalidLatitudeRange() {
+        // given
+        Double minLongitude = 126.9;
+        Double minLatitude = 37.6;
+        Double maxLongitude = 127.1;
+        Double maxLatitude = 37.5;
+
+        // when & then
+        assertThatThrownBy(() -> storyService.getRectangleMapInfoList(
+            minLongitude, minLatitude, maxLongitude, maxLatitude
+        )).isInstanceOf(BaseException.class);
+
+        then(storySpotRepository).should(never())
+            .findByBoundingBox(anyDouble(), anyDouble(), anyDouble(), anyDouble());
+    }
+
+    private StorySpot createStorySpot(Long id, Double longitude, Double latitude) {
+        Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(longitude, latitude));
+
+        return StorySpot.builder()
+            .id(id)
+            .center(point)
+            .geohash("geohash" + id)
+            .build();
+    }
+}

--- a/src/test/java/com/earseo/story/service/StoryServiceMapInfoTest.java
+++ b/src/test/java/com/earseo/story/service/StoryServiceMapInfoTest.java
@@ -135,6 +135,56 @@ class StoryServiceMapInfoTest {
             .findByBoundingBox(anyDouble(), anyDouble(), anyDouble(), anyDouble());
     }
 
+    @Test
+    @DisplayName("중심점 반경 내의 이야기 스팟 목록을 조회한다")
+    void getCircleMapInfo_success() {
+        // given
+        Double meters = 1000.0;
+        Double longitude = 126.9780;
+        Double latitude = 37.5665;
+
+        StorySpot spot1 = createStorySpot(1L, 126.9790, 37.5670);
+        StorySpot spot2 = createStorySpot(2L, 126.9800, 37.5675);
+        StorySpot spot3 = createStorySpot(3L, 126.9770, 37.5660);
+
+        List<StorySpot> mockSpots = List.of(spot1, spot2, spot3);
+
+        given(storySpotRepository.findByRadius(longitude, latitude, meters))
+            .willReturn(mockSpots);
+
+        // when
+        MapSpotInfoList result = storyService.getCircleMapInfo(meters, longitude, latitude);
+
+        // then
+        assertThat(result.storySpots()).hasSize(3);
+        assertThat(result.storySpots().get(0).longitude()).isEqualTo(126.9790);
+        assertThat(result.storySpots().get(0).latitude()).isEqualTo(37.5670);
+        assertThat(result.storySpots().get(0).storySpotId()).isEqualTo(1L);
+
+        then(storySpotRepository).should(times(1))
+            .findByRadius(longitude, latitude, meters);
+    }
+
+    @Test
+    @DisplayName("반경 내에 스팟이 없는 경우 빈 목록을 반환한다")
+    void getCircleMapInfo_emptyResult() {
+        // given
+        Double meters = 1000.0;
+        Double longitude = 126.9780;
+        Double latitude = 37.5665;
+
+        given(storySpotRepository.findByRadius(longitude, latitude, meters))
+            .willReturn(List.of());
+
+        // when
+        MapSpotInfoList result = storyService.getCircleMapInfo(meters, longitude, latitude);
+
+        // then
+        assertThat(result.storySpots()).isEmpty();
+        then(storySpotRepository).should(times(1))
+            .findByRadius(longitude, latitude, meters);
+    }
+
     private StorySpot createStorySpot(Long id, Double longitude, Double latitude) {
         Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(longitude, latitude));
 

--- a/src/test/java/com/earseo/story/service/StorySpotTitleListTest.java
+++ b/src/test/java/com/earseo/story/service/StorySpotTitleListTest.java
@@ -1,10 +1,12 @@
 package com.earseo.story.service;
 
+import com.earseo.story.dto.response.LocationSpotBriefInfoResponse;
 import com.earseo.story.dto.response.SpotTitleListResponse;
 import com.earseo.story.entity.SpotTitleAggregate;
 import com.earseo.story.entity.StorySpot;
 import com.earseo.story.entity.StoryTitle;
 import com.earseo.story.repository.SpotTitleAggregateRepository;
+import com.earseo.story.repository.StorySpotRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,17 +16,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("이야기 스팟 제목 조회 테스트")
 class StorySpotTitleListTest {
+
+    @Mock
+    private StorySpotRepository storySpotRepository;
 
     @Mock
     private SpotTitleAggregateRepository spotTitleAggregateRepository;
@@ -152,5 +158,117 @@ class StorySpotTitleListTest {
             .storyTitle(title)
             .storyCount(count)
             .build();
+    }
+
+    @Test
+    @DisplayName("좌표로 이야기 스팟 정보를 조회한다")
+    void getLocationSpotBriefInfo_success() {
+        // given
+        Double longitude = 126.9780;
+        Double latitude = 37.5665;
+        String expectedGeoHash = "wydm6";
+        Long storySpotId = 1L;
+
+        StorySpot storySpot = StorySpot.builder()
+            .id(storySpotId)
+            .geohash(expectedGeoHash)
+            .build();
+
+        StoryTitle title1 = StoryTitle.builder()
+            .id(1L)
+            .title("서울 여행")
+            .build();
+
+        StoryTitle title2 = StoryTitle.builder()
+            .id(2L)
+            .title("맛집 투어")
+            .build();
+
+        SpotTitleAggregate aggregate1 = SpotTitleAggregate.builder()
+            .id(1L)
+            .storySpot(storySpot)
+            .storyTitle(title1)
+            .storyCount(10L)
+            .build();
+
+        SpotTitleAggregate aggregate2 = SpotTitleAggregate.builder()
+            .id(2L)
+            .storySpot(storySpot)
+            .storyTitle(title2)
+            .storyCount(8L)
+            .build();
+
+        List<SpotTitleAggregate> mockAggregates = List.of(aggregate1, aggregate2);
+
+        given(storySpotRepository.findByGeohash(anyString()))
+            .willReturn(Optional.of(storySpot));
+        given(spotTitleAggregateRepository.findTop4TitleBySpotId(eq(storySpotId), any(Pageable.class)))
+            .willReturn(mockAggregates);
+
+        // when
+        LocationSpotBriefInfoResponse response = storyService.getLocationSpotBriefInfo(longitude, latitude);
+
+        // then
+        assertThat(response.spotId()).isEqualTo(storySpotId);
+        assertThat(response.titles()).hasSize(2);
+        assertThat(response.titles()).containsExactly("서울 여행", "맛집 투어");
+        then(storySpotRepository).should(times(1)).findByGeohash(anyString());
+        then(spotTitleAggregateRepository).should(times(1))
+            .findTop4TitleBySpotId(eq(storySpotId), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("해당 좌표에 이야기 스팟이 없는 경우 null spotId와 빈 타이틀 목록을 반환한다")
+    void getLocationSpotBriefInfo_noSpotFound() {
+        // given
+        Double longitude = 126.9780;
+        Double latitude = 37.5665;
+
+        given(storySpotRepository.findByGeohash(anyString()))
+            .willReturn(Optional.empty());
+
+        // when
+        LocationSpotBriefInfoResponse response = storyService.getLocationSpotBriefInfo(longitude, latitude);
+
+        // then
+        assertThat(response.spotId()).isNull();
+        assertThat(response.titles()).isEmpty();
+        then(storySpotRepository).should(times(1)).findByGeohash(anyString());
+        then(spotTitleAggregateRepository).should(never())
+            .findTop4TitleBySpotId(any(), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("이야기 스팟에 4개의 타이틀이 있는 경우 모두 반환한다")
+    void getLocationSpotBriefInfo_withFourTitles() {
+        // given
+        Double longitude = 126.9780;
+        Double latitude = 37.5665;
+        Long storySpotId = 1L;
+
+        StorySpot storySpot = StorySpot.builder()
+            .id(storySpotId)
+            .geohash("wydm6")
+            .build();
+
+        List<SpotTitleAggregate> mockAggregates = List.of(
+            createAggregate(1L, storySpot, "타이틀1", 100L),
+            createAggregate(2L, storySpot, "타이틀2", 90L),
+            createAggregate(3L, storySpot, "타이틀3", 80L),
+            createAggregate(4L, storySpot, "타이틀4", 70L)
+        );
+
+        given(storySpotRepository.findByGeohash(anyString()))
+            .willReturn(Optional.of(storySpot));
+        given(spotTitleAggregateRepository.findTop4TitleBySpotId(eq(storySpotId), any(Pageable.class)))
+            .willReturn(mockAggregates);
+
+        // when
+        LocationSpotBriefInfoResponse response = storyService.getLocationSpotBriefInfo(longitude, latitude);
+
+        // then
+        assertThat(response.spotId()).isEqualTo(storySpotId);
+        assertThat(response.titles()).hasSize(4);
+        assertThat(response.titles()).containsExactly("타이틀1", "타이틀2", "타이틀3", "타이틀4");
     }
 }

--- a/src/test/java/com/earseo/story/service/StorySpotTitleListTest.java
+++ b/src/test/java/com/earseo/story/service/StorySpotTitleListTest.java
@@ -1,0 +1,156 @@
+package com.earseo.story.service;
+
+import com.earseo.story.dto.response.SpotTitleListResponse;
+import com.earseo.story.entity.SpotTitleAggregate;
+import com.earseo.story.entity.StorySpot;
+import com.earseo.story.entity.StoryTitle;
+import com.earseo.story.repository.SpotTitleAggregateRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("이야기 스팟 제목 조회 테스트")
+class StorySpotTitleListTest {
+
+    @Mock
+    private SpotTitleAggregateRepository spotTitleAggregateRepository;
+
+    @InjectMocks
+    private StoryService storyService;
+
+    @Test
+    @DisplayName("이야기 스팟의 상위 이야기 제목 목록을 조회한다")
+    void getSpotTitleList_success() {
+        // given
+        Long storySpotId = 1L;
+
+        StorySpot storySpot = StorySpot.builder()
+            .id(storySpotId)
+            .build();
+
+        StoryTitle title1 = StoryTitle.builder()
+            .id(1L)
+            .title("서울 여행")
+            .build();
+
+        StoryTitle title2 = StoryTitle.builder()
+            .id(2L)
+            .title("맛집 투어")
+            .build();
+
+        StoryTitle title3 = StoryTitle.builder()
+            .id(3L)
+            .title("카페 탐방")
+            .build();
+
+        SpotTitleAggregate aggregate1 = SpotTitleAggregate.builder()
+            .id(1L)
+            .storySpot(storySpot)
+            .storyTitle(title1)
+            .storyCount(10L)
+            .build();
+
+        SpotTitleAggregate aggregate2 = SpotTitleAggregate.builder()
+            .id(2L)
+            .storySpot(storySpot)
+            .storyTitle(title2)
+            .storyCount(8L)
+            .build();
+
+        SpotTitleAggregate aggregate3 = SpotTitleAggregate.builder()
+            .id(3L)
+            .storySpot(storySpot)
+            .storyTitle(title3)
+            .storyCount(5L)
+            .build();
+
+        List<SpotTitleAggregate> mockAggregates = List.of(aggregate1, aggregate2, aggregate3);
+
+        given(spotTitleAggregateRepository.findTop4TitleBySpotId(eq(storySpotId), any(Pageable.class)))
+            .willReturn(mockAggregates);
+
+        // when
+        SpotTitleListResponse response = storyService.getSpotTitleList(storySpotId);
+
+        // then
+        assertThat(response.titles()).hasSize(3);
+        assertThat(response.titles()).containsExactly("서울 여행", "맛집 투어", "카페 탐방");
+        then(spotTitleAggregateRepository).should(times(1))
+            .findTop4TitleBySpotId(eq(storySpotId), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("이야기 스팟에 이야기 제목이 없는 경우 빈 목록을 반환한다")
+    void getSpotTitleList_emptyList() {
+        // given
+        Long storySpotId = 999L;
+        List<SpotTitleAggregate> emptyList = List.of();
+
+        given(spotTitleAggregateRepository.findTop4TitleBySpotId(eq(storySpotId), any(Pageable.class)))
+            .willReturn(emptyList);
+
+        // when
+        SpotTitleListResponse response = storyService.getSpotTitleList(storySpotId);
+
+        // then
+        assertThat(response.titles()).isEmpty();
+        then(spotTitleAggregateRepository).should(times(1))
+            .findTop4TitleBySpotId(eq(storySpotId), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("이야기 스팟에 4개 이상의 이야기 제목이 있는 경우 상위 4개만 반환한다")
+    void getSpotTitleList_moreThanFour() {
+        // given
+        Long storySpotId = 1L;
+
+        StorySpot storySpot = StorySpot.builder()
+            .id(storySpotId)
+            .build();
+
+        List<SpotTitleAggregate> mockAggregates = List.of(
+            createAggregate(1L, storySpot, "제목1", 100L),
+            createAggregate(2L, storySpot, "제목2", 90L),
+            createAggregate(3L, storySpot, "제목3", 80L),
+            createAggregate(4L, storySpot, "제목4", 70L)
+        );
+
+        given(spotTitleAggregateRepository.findTop4TitleBySpotId(eq(storySpotId), any(Pageable.class)))
+            .willReturn(mockAggregates);
+
+        // when
+        SpotTitleListResponse response = storyService.getSpotTitleList(storySpotId);
+
+        // then
+        assertThat(response.titles()).hasSize(4);
+        assertThat(response.titles()).containsExactly("제목1", "제목2", "제목3", "제목4");
+    }
+
+    private SpotTitleAggregate createAggregate(Long id, StorySpot spot, String titleText, Long count) {
+        StoryTitle title = StoryTitle.builder()
+            .id(id)
+            .title(titleText)
+            .build();
+
+        return SpotTitleAggregate.builder()
+            .id(id)
+            .storySpot(spot)
+            .storyTitle(title)
+            .storyCount(count)
+            .build();
+    }
+}


### PR DESCRIPTION
## 🧩 구현/변경 사항
- 이야기 생성
- 이야기 스팟 생성
- 좌표 기반 이야기 스팟 간단 정보 조회
- 이야기 스팟의 상위 이야기 제목 목록 조회
- 위경도 사각 영역 기준 이야기 스팟 조회
- 반경 기준 이야기 스팟 조회
- 이야기 스팟 검색

---

## ERD
<img width="844" height="596" alt="image" src="https://github.com/user-attachments/assets/a75bab5f-39e6-42cc-9028-9346564e4d20" />

---

## 🧪 테스트 결과
<img width="560" height="501" alt="image" src="https://github.com/user-attachments/assets/4229249b-1a21-4096-b1e0-f047eb5b58e3" />

---

## BREAKING CHANGE (옵션)
- 이야기 스팟 제목의 집계 테이블을 만들어 조회 성능을 끌어올렸습니다.

---

## 참고
- 현재 키워드 검색에 `ILIKE` 문을 사용하고 있어 성능 체크를 계속해서 하며 필요하다면 `trigram`과 같은 추가 인덱스 도입이 필요합니다.
- 시크릿 리소스로 S3 관련 환경변수 추가가 필요합니다.

closes #4 