### PR TITLE
[#6] 이야기 스팟의 이야기 요약 및 전체 정보 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,11 @@ dependencies {
 	implementation 'org.locationtech.jts:jts-core:1.19.0'
 	implementation 'ch.hsr:geohash:1.4.0' // Geohash
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE' // AWS
+
+	implementation 'org.springframework.ai:spring-ai-client-chat:1.1.0'
+	implementation 'org.springframework.ai:spring-ai-openai:1.1.0'
+
+	implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.12.0' // JSONB 타입 활용을 위해 사용
 }
 
 tasks.named('test') {

--- a/k8s/helm-value.yaml
+++ b/k8s/helm-value.yaml
@@ -1,2 +1,2 @@
 image:
-  tag: v0.1.1
+  tag: v0.1.2

--- a/src/main/java/com/earseo/story/common/config/OpenAiConfig.java
+++ b/src/main/java/com/earseo/story/common/config/OpenAiConfig.java
@@ -1,0 +1,39 @@
+package com.earseo.story.common.config;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAiConfig {
+    @Value("${openai.credential.access-key}")
+    private String openAiApiKey;
+    @Value("${openai.model:gpt-4o-mini}")
+    private String openAiModel;
+    @Value("${openai.temperature:0.1}")
+    private Double openAiTemperature;
+    @Value("${openai.top-p:0.9}")
+    private Double topP;
+    @Value("${openai.max-token:}")
+    private Integer openAiMaxToken;
+
+    @Bean
+    public ChatClient storySummaryChatClient() {
+        return ChatClient.builder(OpenAiChatModel.builder()
+                .openAiApi(OpenAiApi.builder()
+                    .apiKey(openAiApiKey)
+                    .build())
+                .defaultOptions(OpenAiChatOptions.builder()
+                    .model(openAiModel)
+                    .temperature(openAiTemperature)
+                    .topP(0.9)
+                    .maxTokens(openAiMaxToken)
+                    .build())
+                .build())
+            .build();
+    }
+}

--- a/src/main/java/com/earseo/story/common/config/SchedulerConfig.java
+++ b/src/main/java/com/earseo/story/common/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.earseo.story.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/com/earseo/story/common/exception/StorySpotError.java
+++ b/src/main/java/com/earseo/story/common/exception/StorySpotError.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum StorySpotError implements ErrorCodeInterface {
 
-    STORY_SPOT_ERROR("STS001", "스토리 스팟에러를 입력해주세요.", HttpStatus.I_AM_A_TEAPOT),
+    STORY_SPOT_NOT_FOUND("STS001", "없는 스토리 스팟입니다.", HttpStatus.NOT_FOUND),
     ;
 
     private final String status;
@@ -18,9 +18,9 @@ public enum StorySpotError implements ErrorCodeInterface {
     @Override
     public ErrorCode getErrorCode() {
         return ErrorCode.builder()
-                .status(status)
-                .message(message)
-                .httpStatus(httpStatus)
-                .build();
+            .status(status)
+            .message(message)
+            .httpStatus(httpStatus)
+            .build();
     }
 }

--- a/src/main/java/com/earseo/story/controller/StoryController.java
+++ b/src/main/java/com/earseo/story/controller/StoryController.java
@@ -1,10 +1,9 @@
 package com.earseo.story.controller;
 
 import com.earseo.story.common.BaseResponse;
-import com.earseo.story.dto.response.LocationSpotBriefInfoResponse;
-import com.earseo.story.dto.response.MapSpotInfoList;
-import com.earseo.story.dto.response.SearchSpotInfoList;
-import com.earseo.story.dto.response.SpotTitleListResponse;
+import com.earseo.story.dto.request.StoryPageRequest;
+import com.earseo.story.dto.response.*;
+import com.earseo.story.entity.Locale;
 import com.earseo.story.service.StoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -15,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.constraints.*;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -474,4 +474,64 @@ public class StoryController {
         ));
     }
 
+    @Operation(
+        summary = "스팟 전체 정보 조회",
+        description = """
+            특정 스팟의 상세 정보를 조회합니다.
+            
+            정렬 옵션:
+            - createdAt,desc : 최신순
+            - createdAt,asc : 오래된순
+            - likeCount,desc : 좋아요순
+            """
+    )
+    @GetMapping("/spot/{storySpotId}/info")
+    public ResponseEntity<BaseResponse<SpotTotalInfoResponse>> getSpotTotalInfo(
+        @Parameter(
+            description = "기준 경도",
+            required = true,
+            example = "126.9780",
+            schema = @Schema(minimum = "124", maximum = "133")
+        )
+        @RequestParam
+        @NotNull(message = "경도는 필수입니다")
+        @DecimalMin(value = "124", message = "경도는 124 이상이어야 합니다")
+        @DecimalMax(value = "133", message = "경도는 133 이하여야 합니다")
+        Double longitude,
+
+        @Parameter(
+            description = "기준 위도",
+            required = true,
+            example = "37.5665",
+            schema = @Schema(minimum = "33.0", maximum = "39")
+        )
+        @RequestParam
+        @NotNull(message = "위도는 필수입니다")
+        @DecimalMin(value = "33.0", message = "위도는 33 이상이어야 합니다")
+        @DecimalMax(value = "39", message = "위도는 39 이하여야 합니다")
+        Double latitude,
+
+        @Parameter(
+            description = "사용자 언어",
+            required = true,
+            example = "KO"
+        )
+        @RequestParam
+        @NotNull(message = "언어는 필수입니다")
+        Locale locale,
+        @Parameter(description = "이야기 스팟 ID", required = true, example = "1")
+        @PathVariable Long storySpotId,
+
+        @ParameterObject
+        StoryPageRequest pageRequest
+    ) {
+        SpotTotalInfoResponse response = storyService.getSpotTotalInfo(
+            storySpotId,
+            longitude,
+            latitude,
+            locale,
+            pageRequest.toPageable()
+        );
+        return ResponseEntity.ok(BaseResponse.ok(response));
+    }
 }

--- a/src/main/java/com/earseo/story/controller/StoryController.java
+++ b/src/main/java/com/earseo/story/controller/StoryController.java
@@ -485,6 +485,16 @@ public class StoryController {
             - likeCount,desc : 좋아요순
             """
     )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = SpotTotalInfoResponse.class)
+            )
+        )
+    })
     @GetMapping("/spot/{storySpotId}/info")
     public ResponseEntity<BaseResponse<SpotTotalInfoResponse>> getSpotTotalInfo(
         @Parameter(
@@ -533,5 +543,36 @@ public class StoryController {
             pageRequest.toPageable()
         );
         return ResponseEntity.ok(BaseResponse.ok(response));
+    }
+
+    @Operation(
+        summary = "스팟 이야기 목록 조회",
+        description = """
+            특정 스팟의 이야기 목록을 조회합니다.
+            
+            정렬 옵션:
+            - createdAt,desc : 최신순
+            - createdAt,asc : 오래된순
+            - likeCount,desc : 좋아요순
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = SpotStoryPageResponse.class)
+            )
+        )
+    })
+    @GetMapping("/spot/{storySpotId}/stories")
+    public ResponseEntity<BaseResponse<SpotStoryPageResponse>> getSpotStorieSlice(
+        @Parameter(description = "이야기 스팟 ID", required = true, example = "1")
+        @PathVariable Long storySpotId,
+        @ParameterObject
+        StoryPageRequest pageRequest
+    ) {
+        return ResponseEntity.ok(BaseResponse.ok(storyService.getSpotStorieSlice(storySpotId, pageRequest.toPageable())));
     }
 }

--- a/src/main/java/com/earseo/story/dto/request/StoryPageRequest.java
+++ b/src/main/java/com/earseo/story/dto/request/StoryPageRequest.java
@@ -1,0 +1,33 @@
+package com.earseo.story.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@Getter
+public class StoryPageRequest {
+    @Schema(description = "페이지 번호 (0부터 시작)", example = "0", defaultValue = "0")
+    private int page = 0;
+
+    @Schema(description = "페이지 크기", example = "10", defaultValue = "10")
+    private int size = 10;
+
+    @Schema(
+        description = "정렬 기준",
+        example = "createdAt,desc",
+        allowableValues = {"createdAt,desc", "createdAt,asc", "likeCount,desc", "likeCount,asc"}
+    )
+    private String sort = "createdAt,desc";
+
+    public Pageable toPageable() {
+        String[] sortParts = sort.split(",");
+        String property = sortParts[0];
+        Sort.Direction direction = sortParts.length > 1
+            ? Sort.Direction.fromString(sortParts[1])
+            : Sort.Direction.DESC;
+
+        return PageRequest.of(page, size, Sort.by(direction, property));
+    }
+}

--- a/src/main/java/com/earseo/story/dto/response/SpotInfoResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/SpotInfoResponse.java
@@ -1,6 +1,7 @@
 package com.earseo.story.dto.response;
 
 import com.earseo.story.entity.StorySpot;
+import com.earseo.story.repository.projectionDto.StorySpotWithDistanceProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record SpotInfoResponse(
@@ -13,5 +14,9 @@ public record SpotInfoResponse(
 ) {
     public static SpotInfoResponse toDto(StorySpot entity) {
         return new SpotInfoResponse(entity.getCenter().getX(), entity.getCenter().getY(), entity.getId());
+    }
+
+    public static SpotInfoResponse toDto(StorySpotWithDistanceProjection storySpotWithDistanceProjection) {
+        return new SpotInfoResponse(storySpotWithDistanceProjection.getLongitude(), storySpotWithDistanceProjection.getLatitude(), storySpotWithDistanceProjection.getStorySpotId());
     }
 }

--- a/src/main/java/com/earseo/story/dto/response/SpotStoryPageResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/SpotStoryPageResponse.java
@@ -1,0 +1,39 @@
+package com.earseo.story.dto.response;
+
+import com.earseo.story.entity.Story;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+import java.util.Map;
+
+public record SpotStoryPageResponse(
+    @Schema(description = "이야기 목록 (페이징/정렬 반영)")
+    List<StoryInfoResponse> stories,
+    @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
+    int number,
+    @Schema(description = "페이지 크기", example = "10")
+    int size,
+    @Schema(description = "첫 페이지 여부", example = "true")
+    boolean isFirst,
+    @Schema(description = "마지막 페이지 여부", example = "false")
+    boolean isLast,
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    boolean hasNext,
+    @Schema(description = "이전 페이지 존재 여부", example = "false")
+    boolean hasPrevious
+) {
+    public static SpotStoryPageResponse toDto(Slice<Story> storyPage, Map<Long, List<String>> imageUrlsMap) {
+        return new SpotStoryPageResponse(
+            storyPage.getContent().stream()
+                .map(story -> StoryInfoResponse.toDto(story, imageUrlsMap.getOrDefault(story.getId(), List.of())))
+                .toList(),
+            storyPage.getNumber(),
+            storyPage.getSize(),
+            storyPage.isFirst(),
+            storyPage.isLast(),
+            storyPage.hasNext(),
+            storyPage.hasPrevious()
+        );
+    }
+}

--- a/src/main/java/com/earseo/story/dto/response/SpotTotalInfoResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/SpotTotalInfoResponse.java
@@ -5,7 +5,7 @@ import com.earseo.story.entity.Story;
 import com.earseo.story.entity.StorySpotSummary;
 import com.earseo.story.repository.projectionDto.StorySpotWithDistanceProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 import java.util.Map;
@@ -25,7 +25,7 @@ public record SpotTotalInfoResponse(
     public static SpotTotalInfoResponse toDto(
         StorySpotWithDistanceProjection storySpotWithDistanceProjection,
         List<SpotTitleAggregate> topTitles,
-        Page<Story> storyPage,
+        Slice<Story> storyPage,
         Map<Long, List<String>> imageUrlsMap,
         List<StorySpotSummary> summaries
     ) {

--- a/src/main/java/com/earseo/story/dto/response/SpotTotalInfoResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/SpotTotalInfoResponse.java
@@ -1,0 +1,44 @@
+package com.earseo.story.dto.response;
+
+import com.earseo.story.entity.SpotTitleAggregate;
+import com.earseo.story.entity.Story;
+import com.earseo.story.entity.StorySpotSummary;
+import com.earseo.story.repository.projectionDto.StorySpotWithDistanceProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.Map;
+
+public record SpotTotalInfoResponse(
+    @Schema(description = "기본 이야기 스팟 정보")
+    SpotInfoResponse briefSpotInfo,
+    @Schema(description = "상위 4개 이야기 제목 목록 (이야기 많은 순서)")
+    SpotTitleListResponse spotTitleList,
+    @Schema(description = "요청한 좌표로부터 거리 (미터)", example = "50.6")
+    Double distance,
+    @Schema(description = "이야기 목록 (페이징/정렬 반영)")
+    List<StoryInfoResponse> stories,
+    @Schema(description = "이 스팟의 요약 목록 (요청 언어 기준, 카테고리별)")
+    List<StorySummaryResponse> summaries
+) {
+    public static SpotTotalInfoResponse toDto(
+        StorySpotWithDistanceProjection storySpotWithDistanceProjection,
+        List<SpotTitleAggregate> topTitles,
+        Page<Story> storyPage,
+        Map<Long, List<String>> imageUrlsMap,
+        List<StorySpotSummary> summaries
+    ) {
+        return new SpotTotalInfoResponse(
+            SpotInfoResponse.toDto(storySpotWithDistanceProjection),
+            SpotTitleListResponse.toDto(topTitles),
+            storySpotWithDistanceProjection.getDistance(),
+            storyPage.getContent().stream()
+                .map(story -> StoryInfoResponse.toDto(story, imageUrlsMap.getOrDefault(story.getId(), List.of())))
+                .toList(),
+            summaries.stream()
+                .map(StorySummaryResponse::toDto)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/com/earseo/story/dto/response/StoryAuthorResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/StoryAuthorResponse.java
@@ -1,6 +1,5 @@
 package com.earseo.story.dto.response;
 
-import com.earseo.story.entity.Story;
 import com.earseo.story.entity.StoryAuthor;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -13,6 +12,7 @@ public record StoryAuthorResponse(
     String profileUrl
 ) {
     public static StoryAuthorResponse toDto(StoryAuthor storyAuthor) {
+        if (storyAuthor == null) return new StoryAuthorResponse(null, null, null);
         return new StoryAuthorResponse(
             storyAuthor.getId(),
             storyAuthor.getNickname(),

--- a/src/main/java/com/earseo/story/dto/response/StoryAuthorResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/StoryAuthorResponse.java
@@ -1,0 +1,22 @@
+package com.earseo.story.dto.response;
+
+import com.earseo.story.entity.Story;
+import com.earseo.story.entity.StoryAuthor;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record StoryAuthorResponse(
+    @Schema(description = "이야기 작성자 ID", example = "10")
+    Long storyAuthorId,
+    @Schema(description = "작성자 닉네임", example = "이어동")
+    String nickname,
+    @Schema(description = "작성자 프로필 이미지 주소", example = "https://cdn.example.com/user/profile/10.jpg")
+    String profileUrl
+) {
+    public static StoryAuthorResponse toDto(StoryAuthor storyAuthor) {
+        return new StoryAuthorResponse(
+            storyAuthor.getId(),
+            storyAuthor.getNickname(),
+            storyAuthor.getProfileUrl()
+        );
+    }
+}

--- a/src/main/java/com/earseo/story/dto/response/StoryInfoResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/StoryInfoResponse.java
@@ -1,0 +1,47 @@
+package com.earseo.story.dto.response;
+
+import com.earseo.story.entity.Locale;
+import com.earseo.story.entity.Story;
+import com.earseo.story.entity.StoryConcept;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record StoryInfoResponse(
+    @Schema(description = "이야기 작성자")
+    StoryAuthorResponse storyAuthor,
+    @Schema(description = "이야기 제목", example = "경복궁의 맛집")
+    String title,
+    @Schema(description = "이야기 내용", example = "여기 건물 앞에 있는 포장마차가 떡볶이 맛집이에요.")
+    String content,
+    @Schema(description = "작성 언어", example = "KO")
+    Locale locale,
+    @Schema(description = "이야기 카테고리", example = "TIP")
+    StoryConcept storyConcept,
+    @Schema(description = "좋아요 개수", example = "37")
+    Long likeCount,
+    @Schema(description = "작성 시각", example = "[2025,11,25,10,32,11,385554000]")
+    LocalDateTime createdAt,
+    @Schema(description = "수정 시각", example = "[2025,11,25,18,32,19,123454000]")
+    LocalDateTime updatedAt,
+    @Schema(description = "이야기 이미지 주소 목록")
+    List<String> imageUrls
+) {
+    public static StoryInfoResponse toDto(Story story, List<String> imageUrls) {
+        StoryAuthorResponse authorResponse = story.getStoryAuthor() != null
+            ? StoryAuthorResponse.toDto(story.getStoryAuthor()) : null;
+
+        return new StoryInfoResponse(
+            authorResponse,
+            story.getStoryTitle().getTitle(),
+            story.getContent(),
+            story.getLocale(),
+            story.getStoryConcept(),
+            story.getLikeCount(),
+            story.getCreatedAt(),
+            story.getUpdatedAt(),
+            imageUrls
+        );
+    }
+}

--- a/src/main/java/com/earseo/story/dto/response/StoryInfoResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/StoryInfoResponse.java
@@ -29,11 +29,8 @@ public record StoryInfoResponse(
     List<String> imageUrls
 ) {
     public static StoryInfoResponse toDto(Story story, List<String> imageUrls) {
-        StoryAuthorResponse authorResponse = story.getStoryAuthor() != null
-            ? StoryAuthorResponse.toDto(story.getStoryAuthor()) : null;
-
         return new StoryInfoResponse(
-            authorResponse,
+            StoryAuthorResponse.toDto(story.getStoryAuthor()),
             story.getStoryTitle().getTitle(),
             story.getContent(),
             story.getLocale(),

--- a/src/main/java/com/earseo/story/dto/response/StorySummaryResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/StorySummaryResponse.java
@@ -1,0 +1,37 @@
+package com.earseo.story.dto.response;
+
+import com.earseo.story.entity.StoryConcept;
+import com.earseo.story.entity.StorySpotSummary;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record StorySummaryResponse(
+    @Schema(description = "이야기 스팟 요약 ID", example = "1234")
+    Long storySpotSummaryId,
+    @Schema(description = "요약의 카테고리", example = "HISTORY")
+    StoryConcept storyConcept,
+    @Schema(description = "도슨트 주소", example = "https://cdn.example.com/docent/audio/1234.mp3")
+    String docentUrl,
+    @Schema(description = "요약 제목", example = "역사적 명소의 종합 요약")
+    String title,
+    @Schema(description = "스토리 요약 본문", example = "이곳은 과거 문화유산으로 유명합니다.")
+    String summary,
+    @Schema(description = "요약 대상 스토리 ID 집합", example = "[10,201,502]")
+    Set<Long> summarizedStoryIdSet,
+    @Schema(description = "수정 시각", example = "[2025,11,25,06,00,01,823454000]")
+    LocalDateTime updatedAt
+) {
+    public static StorySummaryResponse toDto(StorySpotSummary summary) {
+        return new StorySummaryResponse(
+            summary.getId(),
+            summary.getStoryConcept(),
+            summary.getDocentUrl(),
+            summary.getTitle(),
+            summary.getSummary(),
+            summary.getSummarizedStoryIdSet(),
+            summary.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/earseo/story/entity/Locale.java
+++ b/src/main/java/com/earseo/story/entity/Locale.java
@@ -1,7 +1,9 @@
 package com.earseo.story.entity;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
 @AllArgsConstructor
 public enum Locale {
     KO("한국어", "Korean"),

--- a/src/main/java/com/earseo/story/entity/StoryConcept.java
+++ b/src/main/java/com/earseo/story/entity/StoryConcept.java
@@ -1,7 +1,9 @@
 package com.earseo.story.entity;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
 @AllArgsConstructor
 public enum StoryConcept {
     TIP("꿀팁", "Tip"),

--- a/src/main/java/com/earseo/story/entity/StorySpotSummary.java
+++ b/src/main/java/com/earseo/story/entity/StorySpotSummary.java
@@ -1,14 +1,17 @@
 package com.earseo.story.entity;
 
+import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
+import org.hibernate.annotations.Type;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -16,6 +19,15 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
+@Table(
+    uniqueConstraints = {@UniqueConstraint(
+        name = "spot_concept_locale_constraint",
+        columnNames = {"story_spot_id", "story_concept", "locale"}
+    )},
+    indexes = {
+        @Index(name = "spot_concept_locale_idx", columnList = "story_spot_id,story_concept,locale,updated_at DESC"),
+    }
+)
 public class StorySpotSummary {
     @Id
     @Column(name = "story_spot_summary_id")
@@ -25,11 +37,19 @@ public class StorySpotSummary {
     @ManyToOne
     private StorySpot storySpot;
     @Enumerated(EnumType.STRING)
+    @Column(name = "story_concept")
     private StoryConcept storyConcept;
     private String docentUrl;
     @Enumerated(EnumType.STRING)
+    @Column(name = "locale")
     private Locale locale;
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime createdAt;
+    private String title;
+    @Column(columnDefinition = "text")
+    private String summary;
+    @Type(JsonType.class)
+    @Column(name = "summarized_story_id_set", columnDefinition = "JSONB", nullable = false)
+    private Set<Long> summarizedStoryIdSet;
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/earseo/story/repository/SpotTitleAggregateRepository.java
+++ b/src/main/java/com/earseo/story/repository/SpotTitleAggregateRepository.java
@@ -30,7 +30,7 @@ public interface SpotTitleAggregateRepository extends JpaRepository<SpotTitleAgg
             ORDER BY s.storyCount DESC, s.updatedAt DESC
         """)
     @EntityGraph(attributePaths = {"storyTitle"})
-    List<SpotTitleAggregate> findTop4TitleBySpotId(@Param("storySpotId") Long storySpotId, Pageable pageable);
+    List<SpotTitleAggregate> findTopTitleBySpotId(@Param("storySpotId") Long storySpotId, Pageable pageable);
 
     @Query(value = """
         WITH ranked_titles AS (

--- a/src/main/java/com/earseo/story/repository/StoryImageRepository.java
+++ b/src/main/java/com/earseo/story/repository/StoryImageRepository.java
@@ -2,6 +2,17 @@ package com.earseo.story.repository;
 
 import com.earseo.story.entity.StoryImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface StoryImageRepository extends JpaRepository<StoryImage, Long> {
+    @Query("""
+        SELECT si
+        FROM StoryImage si
+        WHERE si.story.id IN :storyIds
+        ORDER BY si.story.id, si.id
+        """)
+    List<StoryImage> findByStoryIdIn(@Param("storyIds") List<Long> storyIds);
 }

--- a/src/main/java/com/earseo/story/repository/StoryJdbcRepository.java
+++ b/src/main/java/com/earseo/story/repository/StoryJdbcRepository.java
@@ -37,14 +37,13 @@ public class StoryJdbcRepository {
             return Collections.emptyMap();
         }
 
-        //TODO 좋아요 기능 구현 후에는 ROW_NUMBER 의 ORDER BY 절만 수정
         String sql = """
             WITH ranked_stories AS (
                 SELECT 
                     s.*,
                     ROW_NUMBER() OVER (
                         PARTITION BY s.story_spot_id, s.story_concept 
-                        ORDER BY s.created_at DESC
+                        ORDER BY s.like_count DESC, s.created_at DESC
                     ) as rn
                 FROM story s
                 WHERE s.story_spot_id IN (:hotSpotIds)

--- a/src/main/java/com/earseo/story/repository/StoryJdbcRepository.java
+++ b/src/main/java/com/earseo/story/repository/StoryJdbcRepository.java
@@ -1,0 +1,93 @@
+package com.earseo.story.repository;
+
+import com.earseo.story.entity.Locale;
+import com.earseo.story.entity.Story;
+import com.earseo.story.entity.StoryConcept;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.*;
+
+@Repository
+@RequiredArgsConstructor
+public class StoryJdbcRepository {
+
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    public List<Long> findHotStorySpot(int hotSpotThreshold) {
+        String sql = """
+            SELECT story_spot_id
+            FROM story
+            GROUP BY story_spot_id
+            HAVING COUNT(*) >= :hotSpotThreshold
+            """;
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("hotSpotThreshold", hotSpotThreshold);
+
+        return namedParameterJdbcTemplate.queryForList(sql, params, Long.class);
+    }
+
+
+    public Map<Long, Map<StoryConcept, Set<Story>>> findAllHotStorySummarizeTargetStory(List<Long> hotSpotIds, int storySummaryLimit) {
+        if (hotSpotIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        //TODO 좋아요 기능 구현 후에는 ROW_NUMBER 의 ORDER BY 절만 수정
+        String sql = """
+            WITH ranked_stories AS (
+                SELECT 
+                    s.*,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY s.story_spot_id, s.story_concept 
+                        ORDER BY s.created_at DESC
+                    ) as rn
+                FROM story s
+                WHERE s.story_spot_id IN (:hotSpotIds)
+            )
+            SELECT
+                story_id,
+                story_spot_id,
+                story_concept,
+                locale,
+                content,
+                created_at
+            FROM ranked_stories
+            WHERE rn <= :storySummaryLimit
+            ORDER BY story_spot_id, story_concept, rn
+            """;
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("hotSpotIds", hotSpotIds);
+        params.put("storySummaryLimit", storySummaryLimit);
+
+        Map<Long, Map<StoryConcept, Set<Story>>> result = new HashMap<>();
+
+        namedParameterJdbcTemplate.query(sql, params, rs -> {
+            Long storySpotId = rs.getLong("story_spot_id");
+            StoryConcept storyConcept = StoryConcept.valueOf(rs.getString("story_concept"));
+            Story story = mapRowToStory(rs);
+
+            result
+                .computeIfAbsent(storySpotId, k -> new HashMap<>())
+                .computeIfAbsent(storyConcept, k -> new HashSet<>())
+                .add(story);
+        });
+
+        return result;
+    }
+
+    private Story mapRowToStory(ResultSet rs) throws SQLException {
+        return Story.builder()
+            .id(rs.getLong("story_id"))
+            .content(rs.getString("content"))
+            .storyConcept(StoryConcept.valueOf(rs.getString("story_concept")))
+            .locale(Locale.valueOf(rs.getString("locale")))
+            .createdAt(rs.getTimestamp("created_at").toLocalDateTime())
+            .build();
+    }
+}

--- a/src/main/java/com/earseo/story/repository/StoryRepository.java
+++ b/src/main/java/com/earseo/story/repository/StoryRepository.java
@@ -1,8 +1,8 @@
 package com.earseo.story.repository;
 
 import com.earseo.story.entity.Story;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,7 +14,7 @@ public interface StoryRepository extends JpaRepository<Story, Long> {
         SELECT s FROM Story s
         WHERE s.storySpot.id = :storySpotId
         """)
-    Page<Story> findByStorySpotIdAndLocale(
+    Slice<Story> findByStorySpotIdAndLocale(
         @Param("storySpotId") Long storySpotId,
         Pageable pageable
     );

--- a/src/main/java/com/earseo/story/repository/StoryRepository.java
+++ b/src/main/java/com/earseo/story/repository/StoryRepository.java
@@ -1,7 +1,21 @@
 package com.earseo.story.repository;
 
 import com.earseo.story.entity.Story;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StoryRepository extends JpaRepository<Story, Long> {
+    @EntityGraph(attributePaths = {"storyAuthor", "storyTitle", "storySpot"})
+    @Query("""
+        SELECT s FROM Story s
+        WHERE s.storySpot.id = :storySpotId
+        """)
+    Page<Story> findByStorySpotIdAndLocale(
+        @Param("storySpotId") Long storySpotId,
+        Pageable pageable
+    );
 }

--- a/src/main/java/com/earseo/story/repository/StorySpotRepository.java
+++ b/src/main/java/com/earseo/story/repository/StorySpotRepository.java
@@ -1,6 +1,7 @@
 package com.earseo.story.repository;
 
 import com.earseo.story.entity.StorySpot;
+import com.earseo.story.repository.projectionDto.StorySpotWithDistanceProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -39,5 +40,23 @@ public interface StorySpotRepository extends JpaRepository<StorySpot, Long> {
         @Param("longitude") Double longitude,
         @Param("latitude") Double latitude,
         @Param("meters") Double meters
+    );
+
+    @Query(value = """
+        SELECT s.story_spot_id,
+        ST_X(s.center) longitude,
+        ST_Y(s.center) latitude,
+        s.geohash, s.created_at,
+        ST_Distance(
+            center::geography,
+            ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography
+        ) as distance
+        FROM story_spot s
+        WHERE s.story_spot_id = :story_spot_id
+        """, nativeQuery = true)
+    Optional<StorySpotWithDistanceProjection> findByIdWithDistance(
+        @Param("story_spot_id") Long storySpotId,
+        @Param("longitude") Double longitude,
+        @Param("latitude") Double latitude
     );
 }

--- a/src/main/java/com/earseo/story/repository/StorySpotSummaryJdbcRepository.java
+++ b/src/main/java/com/earseo/story/repository/StorySpotSummaryJdbcRepository.java
@@ -1,0 +1,154 @@
+package com.earseo.story.repository;
+
+import com.earseo.story.entity.Locale;
+import com.earseo.story.entity.Story;
+import com.earseo.story.entity.StoryConcept;
+import com.earseo.story.service.OpenAiService.SpotSummaryResult;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.PreparedStatement;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class StorySpotSummaryJdbcRepository {
+
+    private final ObjectMapper objectMapper;
+    private final JdbcTemplate jdbcTemplate;
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    public Map<Long, Map<StoryConcept, Set<Long>>> findAllLastSummarizedStoryIdSet(List<Long> hotSpotIds) {
+        if (hotSpotIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        String sql = """
+            SELECT DISTINCT ON (story_spot_id, story_concept)
+                story_spot_id,
+                story_concept,
+                summarized_story_id_set
+            FROM story_spot_summary
+            WHERE story_spot_id IN (:hotSpotIds)
+            ORDER BY story_spot_id,story_concept,updated_at DESC
+            """;
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("hotSpotIds", hotSpotIds);
+
+        Map<Long, Map<StoryConcept, Set<Long>>> result = new HashMap<>();
+
+        namedParameterJdbcTemplate.query(sql, params, rs -> {
+            Long storySpotId = rs.getLong("story_spot_id");
+            StoryConcept storyConcept = StoryConcept.valueOf(rs.getString("story_concept"));
+            String storyIdSet = rs.getString("summarized_story_id_set");
+            Set<Long> set = deserailizeSummarizedStoryIdSet(storyIdSet);
+
+            result
+                .computeIfAbsent(storySpotId, k -> new HashMap<>())
+                .put(storyConcept, set);
+        });
+
+        return result;
+    }
+
+    @Transactional
+    public long batchUpsert(
+        List<SpotSummarySaveRequest> requests
+    ) {
+        if (requests.isEmpty()) {
+            return 0;
+        }
+
+        String sql = """
+            INSERT INTO story_spot_summary 
+                (story_spot_id, story_concept, locale, title, summary, summarized_story_id_set, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?::jsonb, CURRENT_TIMESTAMP)
+            ON CONFLICT ON CONSTRAINT spot_concept_locale_constraint
+            DO UPDATE SET
+               title = EXCLUDED.title,
+               summary = EXCLUDED.summary,
+               summarized_story_id_set = EXCLUDED.summarized_story_id_set,
+               updated_at = CURRENT_TIMESTAMP 
+            """;
+
+        // 배치 크기를 나눠서 처리 (메모리 효율)
+        int batchSize = 1000;
+        long insertedSummaryCnt = 0;
+        for (int i = 0; i < requests.size(); i += batchSize) {
+            int end = Math.min(i + batchSize, requests.size());
+            List<SpotSummarySaveRequest> batch = requests.subList(i, end);
+
+            jdbcTemplate.batchUpdate(
+                sql,
+                batch,
+                batch.size(),
+                (PreparedStatement ps, SpotSummarySaveRequest request) -> {
+                    ps.setLong(1, request.storySpotId());
+                    ps.setString(2, request.storyConcept().name());
+                    ps.setString(3, request.locale().name());
+                    ps.setString(4, request.title());
+                    ps.setString(5, request.summary());
+                    ps.setString(6, serializeSummarizedStoryIdSet(request.stories()));
+                }
+            );
+
+            insertedSummaryCnt += batch.size();
+        }
+        return insertedSummaryCnt;
+    }
+
+    private Set<Long> deserailizeSummarizedStoryIdSet(String storyIdSet) {
+        try {
+            return objectMapper.readValue(storyIdSet, new TypeReference<Set<Long>>() {
+            });
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to deserialize story IDs", e);
+        }
+    }
+
+    public String serializeSummarizedStoryIdSet(Set<Story> stories) {
+        Set<Long> storyIds = stories.stream()
+            .map(Story::getId)
+            .collect(Collectors.toSet());
+
+        try {
+            return objectMapper.writeValueAsString(storyIds);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize story IDs", e);
+        }
+    }
+
+    public record SpotSummarySaveRequest(
+        Long storySpotId,
+        StoryConcept storyConcept,
+        Locale locale,
+        String title,
+        String summary,
+        Set<Story> stories
+    ) {
+        public static SpotSummarySaveRequest toDto(
+            SpotSummaryResult spotSummaryResult,
+            Long storySpotId,
+            StoryConcept storyConcept,
+            Locale locale,
+            Set<Story> stories
+        ) {
+            return new SpotSummarySaveRequest(
+                storySpotId,
+                storyConcept,
+                locale,
+                spotSummaryResult.title(),
+                spotSummaryResult.summary(),
+                stories
+            );
+        }
+    }
+}

--- a/src/main/java/com/earseo/story/repository/StorySpotSummaryRepository.java
+++ b/src/main/java/com/earseo/story/repository/StorySpotSummaryRepository.java
@@ -1,0 +1,24 @@
+package com.earseo.story.repository;
+
+import com.earseo.story.entity.Locale;
+import com.earseo.story.entity.StorySpotSummary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface StorySpotSummaryRepository extends JpaRepository<StorySpotSummary, Long> {
+    @Query("""
+        SELECT s
+        FROM StorySpotSummary s
+        WHERE
+        s.storySpot.id = :storySpotId
+        AND s.locale = :locale
+        ORDER BY s.storyConcept
+        """)
+    List<StorySpotSummary> findByStorySpotIdAndLocale(
+        @Param("storySpotId") Long storySpotId,
+        @Param("locale") Locale locale
+    );
+}

--- a/src/main/java/com/earseo/story/repository/projectionDto/StorySpotWithDistanceProjection.java
+++ b/src/main/java/com/earseo/story/repository/projectionDto/StorySpotWithDistanceProjection.java
@@ -1,0 +1,12 @@
+package com.earseo.story.repository.projectionDto;
+
+import java.time.LocalDateTime;
+
+public interface StorySpotWithDistanceProjection {
+    Long getStorySpotId();
+    Double getLongitude();
+    Double getLatitude();
+    String getGeohash();
+    LocalDateTime getCreatedAt();
+    Double getDistance();
+}

--- a/src/main/java/com/earseo/story/service/OpenAiService.java
+++ b/src/main/java/com/earseo/story/service/OpenAiService.java
@@ -1,0 +1,68 @@
+package com.earseo.story.service;
+
+import com.earseo.story.entity.Locale;
+import com.earseo.story.entity.Story;
+import com.earseo.story.entity.StoryConcept;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class OpenAiService {
+    private final ChatClient chatClient;
+
+    public SpotSummaryResult generateSummaryWithAI(Set<Story> stories, StoryConcept concept, Locale locale) {
+        String combinedContent = stories.stream()
+            .map(Story::getContent)
+            .collect(Collectors.joining("\n\n---\n\n"));
+
+        String languageInstruction = String.format("You must respond in %s language.", locale.getEnName());
+
+        SpotSummaryResult spotSummaryResult = chatClient.prompt()
+            .system(s -> s.text("""
+                You are an expert content analyst specializing in travel and location-based user-generated content.
+                
+                Your responsibilities:
+                - Analyze multiple user posts and extract key themes
+                - Create concise, accurate summaries that capture the essence of the content
+                - Maintain objectivity and avoid personal opinions
+                - Ensure summaries are informative and easy to understand
+                
+                Output requirements:
+                - Title: 5-10 words, clear and descriptive
+                - Summary: 2-3 complete sentences
+                - Tone: Professional and neutral
+                - Language: Follow the user's language instruction strictly
+                """))
+            .user(u -> u.text("""
+                    Analyze the following user posts from the {concept} category:
+                    
+                    === USER POSTS ===
+                    {content}
+                    === END OF POSTS ===
+                    
+                    Create a summary with:
+                    1. A concise title capturing the main theme
+                    2. A 2-3 sentence summary of key points
+                    
+                    {language}
+                    """)
+                .param("concept", concept.getEnName())
+                .param("content", combinedContent)
+                .param("language", languageInstruction))
+            .call()
+            .entity(SpotSummaryResult.class);
+
+        return spotSummaryResult;
+    }
+
+    public record SpotSummaryResult(
+        String title,
+        String summary
+    ) {
+    }
+}

--- a/src/main/java/com/earseo/story/service/StoryService.java
+++ b/src/main/java/com/earseo/story/service/StoryService.java
@@ -6,25 +6,28 @@ import com.earseo.story.common.exception.BaseException;
 import com.earseo.story.dto.request.CreateRequest;
 import com.earseo.story.dto.response.*;
 import com.earseo.story.entity.*;
+import com.earseo.story.entity.Locale;
 import com.earseo.story.repository.*;
 import com.earseo.story.repository.projectionDto.SearchSpotProjection;
+import com.earseo.story.repository.projectionDto.StorySpotWithDistanceProjection;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.earseo.story.common.exception.StoryError.*;
+import static com.earseo.story.common.exception.StorySpotError.STORY_SPOT_NOT_FOUND;
 
 @Slf4j
 @Service
@@ -35,6 +38,7 @@ public class StoryService {
     private static final GeometryFactory GEOMETRY_FACTORY =
         new GeometryFactory(new PrecisionModel(), SRID_WGS84);
     private static final String STORY_S3_PATH_FORMAT = "story/%s/%d";
+    private static final int STORY_SPOT_CANDIDATE_TITLE_LIMIT = 4;
 
     private final StorySpotRepository storySpotRepository;
     private final StoryAuthorRepository storyAuthorRepository;
@@ -43,6 +47,7 @@ public class StoryService {
     private final StoryImageRepository storyImageRepository;
     private final StoryTitleRepository storyTitleRepository;
     private final SpotTitleAggregateRepository spotTitleAggregateRepository;
+    private final StorySpotSummaryRepository storySpotSummaryRepository;
 
     @Transactional
     public CreateResponse createStory(Long memberId, CreateRequest body, List<MultipartFile> images) {
@@ -170,7 +175,7 @@ public class StoryService {
     }
 
     public SpotTitleListResponse getSpotTitleList(Long storySpotId) {
-        return SpotTitleListResponse.toDto(spotTitleAggregateRepository.findTop4TitleBySpotId(storySpotId, Pageable.ofSize(4)));
+        return SpotTitleListResponse.toDto(spotTitleAggregateRepository.findTopTitleBySpotId(storySpotId, Pageable.ofSize(STORY_SPOT_CANDIDATE_TITLE_LIMIT)));
     }
 
     public LocationSpotBriefInfoResponse getLocationSpotBriefInfo(Double longitude, Double latitude) {
@@ -181,7 +186,7 @@ public class StoryService {
         }
         return LocationSpotBriefInfoResponse.toDto(
             storySpot.get().getId(),
-            spotTitleAggregateRepository.findTop4TitleBySpotId(storySpot.get().getId(), Pageable.ofSize(4))
+            spotTitleAggregateRepository.findTopTitleBySpotId(storySpot.get().getId(), Pageable.ofSize(STORY_SPOT_CANDIDATE_TITLE_LIMIT))
         );
     }
 
@@ -226,5 +231,46 @@ public class StoryService {
             limit
         );
         return SearchSpotInfoList.toDto(responses);
+    }
+
+    public SpotTotalInfoResponse getSpotTotalInfo(
+        Long storySpotId,
+        Double longitude,
+        Double latitude,
+        Locale locale,
+        Pageable pageable
+    ) {
+        // 스팟 정보
+        StorySpotWithDistanceProjection storySpot = storySpotRepository.findByIdWithDistance(storySpotId, longitude, latitude)
+            .orElseThrow(() -> new BaseException(STORY_SPOT_NOT_FOUND));
+
+        // 상위 4개 제목
+        List<SpotTitleAggregate> topTitles = spotTitleAggregateRepository.findTopTitleBySpotId(
+            storySpotId,
+            PageRequest.ofSize(STORY_SPOT_CANDIDATE_TITLE_LIMIT)
+        );
+
+        // 이야기 목록
+        Page<Story> storyPage = storyRepository.findByStorySpotIdAndLocale(
+            storySpotId, pageable
+        );
+
+        // 이미지 조회
+        List<Long> storyIds = storyPage.getContent().stream()
+            .map(Story::getId)
+            .toList();
+        List<StoryImage> storyImages = storyImageRepository.findByStoryIdIn(storyIds);
+
+        Map<Long, List<String>> imageUrlsMap = storyImages.stream()
+            .collect(Collectors.groupingBy(
+                image -> image.getStory().getId(),
+                Collectors.mapping(StoryImage::getImageUrl, Collectors.toList())
+            ));
+
+        // 요약 목록
+        List<StorySpotSummary> summaries = storySpotSummaryRepository
+            .findByStorySpotIdAndLocale(storySpotId, locale);
+
+        return SpotTotalInfoResponse.toDto(storySpot, topTitles, storyPage, imageUrlsMap, summaries);
     }
 }

--- a/src/main/java/com/earseo/story/service/StoryService.java
+++ b/src/main/java/com/earseo/story/service/StoryService.java
@@ -16,9 +16,9 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -251,7 +251,7 @@ public class StoryService {
         );
 
         // 이야기 목록
-        Page<Story> storyPage = storyRepository.findByStorySpotIdAndLocale(
+        Slice<Story> storyPage = storyRepository.findByStorySpotIdAndLocale(
             storySpotId, pageable
         );
 
@@ -272,5 +272,23 @@ public class StoryService {
             .findByStorySpotIdAndLocale(storySpotId, locale);
 
         return SpotTotalInfoResponse.toDto(storySpot, topTitles, storyPage, imageUrlsMap, summaries);
+    }
+
+    public SpotStoryPageResponse getSpotStorieSlice(Long storySpotId, Pageable pageable) {
+        // 이야기 목록
+        Slice<Story> storyPage = storyRepository.findByStorySpotIdAndLocale(storySpotId, pageable);
+
+        // 이미지 조회
+        List<Long> storyIds = storyPage.getContent().stream()
+            .map(Story::getId)
+            .toList();
+        List<StoryImage> storyImages = storyImageRepository.findByStoryIdIn(storyIds);
+
+        Map<Long, List<String>> imageUrlsMap = storyImages.stream()
+            .collect(Collectors.groupingBy(
+                image -> image.getStory().getId(),
+                Collectors.mapping(StoryImage::getImageUrl, Collectors.toList())
+            ));
+        return SpotStoryPageResponse.toDto(storyPage, imageUrlsMap);
     }
 }

--- a/src/main/java/com/earseo/story/service/StorySpotSummaryService.java
+++ b/src/main/java/com/earseo/story/service/StorySpotSummaryService.java
@@ -1,0 +1,111 @@
+package com.earseo.story.service;
+
+import com.earseo.story.entity.Locale;
+import com.earseo.story.entity.Story;
+import com.earseo.story.entity.StoryConcept;
+import com.earseo.story.repository.StoryJdbcRepository;
+import com.earseo.story.repository.StorySpotSummaryJdbcRepository;
+import com.earseo.story.repository.StorySpotSummaryJdbcRepository.SpotSummarySaveRequest;
+import com.earseo.story.service.OpenAiService.SpotSummaryResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StorySpotSummaryService {
+    @Value("${summary.hot-spot.threshold}")
+    private int HOT_SPOT_THRESHOLD;
+    @Value("${summary.story-summary.limit}")
+    private int STORY_SUMMARY_LIMIT;
+    @Value("${summary.story-summary.threshold}")
+    private int STORY_SUMMARY_THRESHOLD;
+
+    private final OpenAiService openAiService;
+    private final StoryJdbcRepository storyJDBCRepository;
+    private final StorySpotSummaryJdbcRepository storySpotSummaryJDBCRepository;
+
+    @Scheduled(cron = "${summary.schedule.cron}")
+    public void createSummariesScheduled() {
+        log.info("Starting summary creation");
+
+        // 핫스팟 찾기
+        List<Long> hotSpotIds = storyJDBCRepository.findHotStorySpot(HOT_SPOT_THRESHOLD);
+        if (hotSpotIds.isEmpty()) {
+            return;
+        }
+
+        // 이전 요약 대상 이야기 id
+        // Map<StorySpotId, Map<StoryConcept, Set<storyId>>>
+        Map<Long, Map<StoryConcept, Set<Long>>> lastSummarizedStoryIdSet =
+            storySpotSummaryJDBCRepository.findAllLastSummarizedStoryIdSet(hotSpotIds);
+
+        // 현재 요약 대상 이야기
+        // Map<StorySpotId, Map<StoryConcept, Set<Story>>>
+        Map<Long, Map<StoryConcept, Set<Story>>> currentSummarizedStoryIdSet =
+            storyJDBCRepository.findAllHotStorySummarizeTargetStory(hotSpotIds, STORY_SUMMARY_LIMIT);
+
+        // 요약 정보를 새로 만들어야 하는 이야기
+        Map<Long, Map<StoryConcept, Set<Story>>> shouldSummarizeStory = new HashMap<>();
+        long summarizeCnt = 0L;
+
+        for (Long hotSpotId : hotSpotIds) {
+            Map<StoryConcept, Set<Story>> currentStories =
+                currentSummarizedStoryIdSet.getOrDefault(hotSpotId, Collections.emptyMap());
+
+            for (StoryConcept storyConcept : StoryConcept.values()) {
+                Set<Story> stories = currentStories.get(storyConcept);
+                if (stories == null || stories.isEmpty()) continue;
+                Set<Long> prevStoryIds = lastSummarizedStoryIdSet
+                    .getOrDefault(hotSpotId, Collections.emptyMap())
+                    .getOrDefault(storyConcept, Collections.emptySet());
+                if (
+                    stories.size() < STORY_SUMMARY_THRESHOLD
+                    || stories.stream().map(Story::getId).collect(Collectors.toSet()).equals(prevStoryIds)
+                ) continue;
+                shouldSummarizeStory
+                    .computeIfAbsent(hotSpotId, k -> new HashMap<>())
+                    .computeIfAbsent(storyConcept, k -> new HashSet<>())
+                    .addAll(stories);
+                summarizeCnt++;
+            }
+        }
+
+        if (summarizeCnt == 0) return;
+
+        List<SpotSummarySaveRequest> spotSummarySaveRequests = new ArrayList<>();
+        // 요약 생성
+        for (Map.Entry<Long, Map<StoryConcept, Set<Story>>> storySpotEntry : shouldSummarizeStory.entrySet()) {
+            for (Map.Entry<StoryConcept, Set<Story>> storyConceptEntry : storySpotEntry.getValue().entrySet()) {
+                for (Locale locale : Locale.values()) {
+                    SpotSummaryResult spotSummaryResult = openAiService.generateSummaryWithAI(
+                        storyConceptEntry.getValue(),
+                        storyConceptEntry.getKey(),
+                        locale
+                    );
+                    SpotSummarySaveRequest spotSummarySaveRequest = SpotSummarySaveRequest
+                        .toDto(
+                            spotSummaryResult,
+                            storySpotEntry.getKey(),
+                            storyConceptEntry.getKey(),
+                            locale,
+                            storyConceptEntry.getValue()
+                        );
+                    spotSummarySaveRequests.add(spotSummarySaveRequest);
+                }
+            }
+        }
+
+        // 요약 저장
+        long insertedSummaryCnt = storySpotSummaryJDBCRepository
+            .batchUpsert(spotSummarySaveRequests);
+
+        log.info("{} Summary Created", insertedSummaryCnt);
+    }
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -12,7 +12,6 @@ spring:
       ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}
     properties:
       hibernate:
-        show_sql: false
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: false
@@ -82,6 +81,7 @@ management:
 logging:
   level:
     org.hibernate.SQL: ${LOGGING_LEVEL_ORG_HIBERNATE_SQL:debug}
+    org.springframework.jdbc.core.JdbcTemplate: ${LOGGING_LEVEL_JDBC_TEMPLATE:debug}
 cloud:
   aws:
     credentials:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -10,7 +10,6 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        show_sql: true
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: false
@@ -66,6 +65,7 @@ management:
 logging:
   level:
     org.hibernate.SQL: ${LOGGING_LEVEL_ORG_HIBERNATE_SQL:debug}
+    org.springframework.jdbc.core.JdbcTemplate: ${LOGGING_LEVEL_JDBC_TEMPLATE:debug}
 cloud:
   aws:
     credentials:

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -7,10 +7,9 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     properties:
       hibernate:
-        show_sql: true
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: false
@@ -61,6 +60,7 @@ management:
 logging:
   level:
     org.hibernate.SQL: ${LOGGING_LEVEL_ORG_HIBERNATE_SQL:debug}
+    org.springframework.jdbc.core.JdbcTemplate: ${LOGGING_LEVEL_JDBC_TEMPLATE:debug}
 cloud:
   aws:
     credentials:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,3 +15,19 @@ springdoc:
     display-request-duration: true
     operations-sorter: method
     tags-sorter: alpha
+
+summary:
+  hot-spot:
+    threshold: ${HOT_SPOT_THRESHOLD:30}
+  story-summary:
+    limit: ${STORY_SUMMARY_LIMIT:3}
+    threshold: ${STORY_SUMMARY_THRESHOLD:3}
+  schedule:
+    cron: ${SUMMARY_SCHEDULE_CRON:0 0 0,6,12,18 * * *}
+openai:
+  credential:
+    access-key: ${CREDENTIAL_OPENAI_ACCESS_KEY:}
+  model: ${OPENAI_MODEL:gpt-4o-mini}
+  temperature: ${OPENAI_TEMPERATURE:1.2}
+  top-p: ${OPENAI_TOP_P:0.9}
+  max-token: ${OPENAI_MAX_TOKEN:}

--- a/src/test/java/com/earseo/story/repository/StorySpotSummaryJdbcRepositoryTest.java
+++ b/src/test/java/com/earseo/story/repository/StorySpotSummaryJdbcRepositoryTest.java
@@ -1,0 +1,323 @@
+package com.earseo.story.repository;
+
+import com.earseo.story.entity.*;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@DisplayName("이야기 요약을 할 때 ")
+class StorySpotSummaryJdbcRepositoryTest {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private StoryJdbcRepository storyJdbcRepository;
+
+    @Autowired
+    private StorySpotSummaryJdbcRepository storySpotSummaryJdbcRepository;
+
+    private StorySpot testSpot1;
+    private StorySpot testSpot2;
+    private StoryTitle testTitle;
+    private GeometryFactory geometryFactory;
+
+    @BeforeEach
+    void setUp() {
+        geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+
+        testSpot1 = StorySpot.builder()
+            .geohash("wydm6m")
+            .center(createPoint(126.9780, 37.5665))
+            .build();
+        entityManager.persist(testSpot1);
+
+        testSpot2 = StorySpot.builder()
+            .geohash("wydm7n")
+            .center(createPoint(126.9784, 37.5635))
+            .build();
+        entityManager.persist(testSpot2);
+
+        testTitle = StoryTitle.builder()
+            .title("Test Title")
+            .build();
+        entityManager.persist(testTitle);
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    private Point createPoint(double longitude, double latitude) {
+        return geometryFactory.createPoint(new Coordinate(longitude, latitude));
+    }
+
+    @Test
+    @DisplayName("기준 이상의 이야기를 가진 핫스팟을 조회한다")
+    void findHotStorySpot_AboveThreshold_ReturnsHotSpots() {
+        // given
+        int hotSpotThreshold = 30;
+        createStories(testSpot1, hotSpotThreshold + 5);
+        createStories(testSpot2, hotSpotThreshold - 5);
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        List<Long> hotSpotIds = storyJdbcRepository.findHotStorySpot(hotSpotThreshold);
+
+        // then
+        assertThat(hotSpotIds).hasSize(1);
+        assertThat(hotSpotIds).contains(testSpot1.getId());
+        assertThat(hotSpotIds).doesNotContain(testSpot2.getId());
+    }
+
+    @Test
+    @DisplayName("핫스팟이 없으면 빈 리스트를 반환한다")
+    void findHotStorySpot_NoHotSpots_ReturnsEmptyList() {
+        // given
+        int hotSpotThreshold = 30;
+        createStories(testSpot1, hotSpotThreshold - 10);
+        createStories(testSpot2, hotSpotThreshold - 5);
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        List<Long> hotSpotIds = storyJdbcRepository.findHotStorySpot(hotSpotThreshold);
+
+        // then
+        assertThat(hotSpotIds).isEmpty();
+    }
+
+    @Test
+    @DisplayName("각 컨셉별로 최신 N개의 스토리를 조회한다")
+    void findAllHotStorySummarizeTargetStory_ReturnsTopNStoriesPerConcept() {
+        // given
+        int storySummaryLimit = 3; // 요약 대상 이야기 개수
+        Story story1 = createAndPersistStory(testSpot1, StoryConcept.HISTORY, "HISTORY1", LocalDateTime.now().minusDays(3));
+        Story story2 = createAndPersistStory(testSpot1, StoryConcept.HISTORY, "HISTORY2", LocalDateTime.now().minusDays(2));
+        Story story3 = createAndPersistStory(testSpot1, StoryConcept.HISTORY, "HISTORY3", LocalDateTime.now().minusDays(1));
+        Story story4 = createAndPersistStory(testSpot1, StoryConcept.HISTORY, "HISTORY4", LocalDateTime.now()); // 가장 최신
+
+        Story story5 = createAndPersistStory(testSpot1, StoryConcept.EXPERIENCE, "EXPERIENCE", LocalDateTime.now());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        Map<Long, Map<StoryConcept, Set<Story>>> result =
+            storyJdbcRepository.findAllHotStorySummarizeTargetStory(
+                List.of(testSpot1.getId()),
+                storySummaryLimit
+            );
+
+        // then
+        assertThat(result).containsKey(testSpot1.getId());
+
+        Set<Story> attractionStories = result.get(testSpot1.getId()).get(StoryConcept.HISTORY);
+        assertThat(attractionStories).hasSize(storySummaryLimit);
+        assertThat(attractionStories).extracting(Story::getId)
+            .containsExactlyInAnyOrder(story2.getId(), story3.getId(), story4.getId());
+        assertThat(attractionStories).extracting(Story::getId)
+            .doesNotContain(story1.getId());  // 가장 오래된 것은 제외
+
+        // FOOD 카테고리: 1개만 있음
+        Set<Story> foodStories = result.get(testSpot1.getId()).get(StoryConcept.EXPERIENCE);
+        assertThat(foodStories).hasSize(1);
+        assertThat(foodStories).extracting(Story::getId)
+            .containsExactly(story5.getId());
+    }
+
+    @Test
+    @DisplayName("여러 핫스팟의 스토리를 한 번에 조회한다")
+    void findAllHotStorySummarizeTargetStory_MultipleSpots_ReturnsAllStories() {
+        // given
+        createAndPersistStory(testSpot1, StoryConcept.HISTORY, "spot1-1", LocalDateTime.now());
+        createAndPersistStory(testSpot1, StoryConcept.HISTORY, "spot1-2", LocalDateTime.now());
+        createAndPersistStory(testSpot1, StoryConcept.EXPERIENCE, "spot1-3", LocalDateTime.now());
+
+        createAndPersistStory(testSpot2, StoryConcept.HISTORY, "spot2-1", LocalDateTime.now());
+        createAndPersistStory(testSpot2, StoryConcept.EXPERIENCE, "spot2-2", LocalDateTime.now());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        Map<Long, Map<StoryConcept, Set<Story>>> result =
+            storyJdbcRepository.findAllHotStorySummarizeTargetStory(
+                List.of(testSpot1.getId(), testSpot2.getId()),
+                3
+            );
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).containsKeys(testSpot1.getId(), testSpot2.getId());
+        assertThat(result.get(testSpot1.getId()).get(StoryConcept.HISTORY)).hasSize(2);
+        assertThat(result.get(testSpot1.getId()).get(StoryConcept.EXPERIENCE)).hasSize(1);
+        assertThat(result.get(testSpot2.getId()).get(StoryConcept.HISTORY)).hasSize(1);
+        assertThat(result.get(testSpot2.getId()).get(StoryConcept.EXPERIENCE)).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("이전 요약의 이야기 id 를 조회한다")
+    void findAllLastSummarizedStoryIdSet_ReturnsLastSummaries() {
+        // given
+        StorySpotSummary summary = StorySpotSummary.builder()
+            .storySpot(testSpot1)
+            .storyConcept(StoryConcept.HISTORY)
+            .locale(Locale.KO)
+            .title("Test Title")
+            .summary("Test Summary")
+            .summarizedStoryIdSet(Set.of(1L, 2L, 3L))
+            .build();
+        entityManager.persist(summary);
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        Map<Long, Map<StoryConcept, Set<Long>>> result =
+            storySpotSummaryJdbcRepository.findAllLastSummarizedStoryIdSet(
+                List.of(testSpot1.getId())
+            );
+
+        // then
+        assertThat(result).containsKey(testSpot1.getId());
+        assertThat(result.get(testSpot1.getId())).containsKey(StoryConcept.HISTORY);
+        assertThat(result.get(testSpot1.getId()).get(StoryConcept.HISTORY))
+            .containsExactlyInAnyOrder(1L, 2L, 3L);
+    }
+
+    @Test
+    @DisplayName("새로운 요약을 저장한다")
+    void batchUpsert_NewData_Inserts() {
+        // given
+        Set<Story> stories = Set.of(
+            createAndPersistStory(testSpot1, StoryConcept.HISTORY, "content1", LocalDateTime.now()),
+            createAndPersistStory(testSpot1, StoryConcept.HISTORY, "content2", LocalDateTime.now()),
+            createAndPersistStory(testSpot1, StoryConcept.HISTORY, "content3", LocalDateTime.now())
+        );
+
+        StorySpotSummaryJdbcRepository.SpotSummarySaveRequest request =
+            new StorySpotSummaryJdbcRepository.SpotSummarySaveRequest(
+                testSpot1.getId(),
+                StoryConcept.HISTORY,
+                Locale.KO,
+                "Test Title",
+                "Test Summary",
+                stories
+            );
+
+        // when
+        long insertCount = storySpotSummaryJdbcRepository.batchUpsert(List.of(request));
+        entityManager.flush();
+        entityManager.clear();
+
+        // then
+        assertThat(insertCount).isEqualTo(1);
+
+        List<StorySpotSummary> summaries = entityManager
+            .createQuery("SELECT s FROM StorySpotSummary s WHERE s.storySpot.id = :spotId", StorySpotSummary.class)
+            .setParameter("spotId", testSpot1.getId())
+            .getResultList();
+
+        assertThat(summaries).hasSize(1);
+        assertThat(summaries.get(0).getTitle()).isEqualTo("Test Title");
+        assertThat(summaries.get(0).getSummary()).isEqualTo("Test Summary");
+    }
+
+    @Test
+    @DisplayName("새로운 요약으로 덮어쓴다")
+    void batchUpsert_ExistingData_Updates() {
+        // given
+        // 기존 요약 저장
+        Set<Story> oldStories = Set.of(
+            createAndPersistStory(testSpot1, StoryConcept.HISTORY, "old1", LocalDateTime.now())
+        );
+        entityManager.flush();
+        entityManager.clear();
+
+        StorySpotSummaryJdbcRepository.SpotSummarySaveRequest oldRequest =
+            new StorySpotSummaryJdbcRepository.SpotSummarySaveRequest(
+                testSpot1.getId(),
+                StoryConcept.HISTORY,
+                Locale.KO,
+                "Old Title",
+                "Old Summary",
+                oldStories
+            );
+
+        storySpotSummaryJdbcRepository.batchUpsert(List.of(oldRequest));
+
+        // when
+        // 같은 키로 다시 저장
+        Set<Story> newStories = Set.of(
+            createAndPersistStory(testSpot1, StoryConcept.HISTORY, "new1", LocalDateTime.now()),
+            createAndPersistStory(testSpot1, StoryConcept.HISTORY, "new2", LocalDateTime.now())
+        );
+        entityManager.flush();
+        entityManager.clear();
+
+        StorySpotSummaryJdbcRepository.SpotSummarySaveRequest newRequest =
+            new StorySpotSummaryJdbcRepository.SpotSummarySaveRequest(
+                testSpot1.getId(),
+                StoryConcept.HISTORY,
+                Locale.KO,
+                "Updated Title",
+                "Updated Summary",
+                newStories
+            );
+
+        long updateCount = storySpotSummaryJdbcRepository.batchUpsert(List.of(newRequest));
+
+        // then
+        // 1개만 존재 (UPDATE)
+        assertThat(updateCount).isEqualTo(1);
+
+        List<StorySpotSummary> summaries = entityManager
+            .createQuery("SELECT s FROM StorySpotSummary s WHERE s.storySpot.id = :spotId AND s.storyConcept = :concept AND s.locale = :locale", StorySpotSummary.class)
+            .setParameter("spotId", testSpot1.getId())
+            .setParameter("concept", StoryConcept.HISTORY)
+            .setParameter("locale", Locale.KO)
+            .getResultList();
+
+        assertThat(summaries).hasSize(1);
+        assertThat(summaries.get(0).getTitle()).isEqualTo("Updated Title");
+        assertThat(summaries.get(0).getSummary()).isEqualTo("Updated Summary");
+    }
+
+    private void createStories(StorySpot spot, int count) {
+        for (int i = 0; i < count; i++) {
+            createAndPersistStory(spot, StoryConcept.HISTORY, "content" + i, LocalDateTime.now());
+        }
+    }
+
+    private Story createAndPersistStory(StorySpot spot, StoryConcept concept, String content, LocalDateTime createdAt) {
+        Story story = Story.builder()
+            .storySpot(spot)
+            .storyConcept(concept)
+            .storyTitle(testTitle)
+            .locale(Locale.KO)
+            .content(content)
+            .createdAt(createdAt)
+            .build();
+        entityManager.persist(story);
+        return story;
+    }
+}

--- a/src/test/java/com/earseo/story/service/OpenAiServiceIntegrationTest.java
+++ b/src/test/java/com/earseo/story/service/OpenAiServiceIntegrationTest.java
@@ -1,0 +1,91 @@
+package com.earseo.story.service;
+
+import com.earseo.story.entity.Locale;
+import com.earseo.story.entity.Story;
+import com.earseo.story.entity.StoryConcept;
+import com.earseo.story.service.OpenAiService.SpotSummaryResult;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Disabled
+@SpringBootTest
+@ActiveProfiles("local")
+@DisplayName("OpenAiService 테스트용 ")
+class OpenAiServiceIntegrationTest {
+
+    @Autowired
+    private OpenAiService openAiService;
+
+    @Test
+    @DisplayName("OpenAI API 영어 요약 생성 (수동 실행용)")
+    void generateSummaryWithAI_RealAPI_GeneratesSummary() {
+        // given
+        Set<Story> stories = Set.of(
+            createStory(1L, "500년 역사를 자랑하는 궁궐입니다."),
+            createStory(2L, "Traditional Korean architecture is stunning."),
+            createStory(3L, "A must-visit cultural heritage site.")
+        );
+
+        // when
+        SpotSummaryResult result = openAiService.generateSummaryWithAI(
+            stories,
+            StoryConcept.HISTORY,
+            Locale.EN
+        );
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.title()).isNotBlank();
+        assertThat(result.summary()).isNotBlank();
+
+        System.out.println("=====OpenAI 응답=====");
+        System.out.println("제목: " + result.title());
+        System.out.println("요약: " + result.summary());
+    }
+
+    @Test
+    @DisplayName("OpenAI API 한국어 요약 생성 (수동 실행용)")
+    void generateSummaryWithAI_RealAPI_Korean_GeneratesSummary() {
+        // given
+        Set<Story> stories = Set.of(
+            createStory(1L, "떡볶이집이 너무 맛있어요. 게다가 떡볶이집에 떡이 무한리필이에요... 사장님 진짜 대박나세요... ㅠ"),
+            createStory(2L, "Makgeolli is really good and the snacks are delicious. It's a place with a lot of foreigners and tourists."),
+            createStory(3L, "여기에서 체험하는 술 문화인 주도가 굉장히 재밌어요. 한국인이지만 몰랐던게 많네,,")
+        );
+
+        // when
+        SpotSummaryResult result = openAiService.generateSummaryWithAI(
+            stories,
+            StoryConcept.HISTORY,
+            Locale.KO
+        );
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.title()).isNotBlank();
+        assertThat(result.summary()).isNotBlank();
+
+        System.out.println("=====OpenAI 응답=====");
+        System.out.println("제목: " + result.title());
+        System.out.println("요약: " + result.summary());
+    }
+
+    private Story createStory(Long id, String content) {
+        return Story.builder()
+            .id(id)
+            .content(content)
+            .storyConcept(StoryConcept.EXPERIENCE)
+            .locale(Locale.EN)
+            .createdAt(LocalDateTime.now())
+            .build();
+    }
+}

--- a/src/test/java/com/earseo/story/service/StorySpotSummaryServiceTest.java
+++ b/src/test/java/com/earseo/story/service/StorySpotSummaryServiceTest.java
@@ -1,0 +1,188 @@
+package com.earseo.story.service;
+
+import com.earseo.story.entity.Locale;
+import com.earseo.story.entity.Story;
+import com.earseo.story.entity.StoryConcept;
+import com.earseo.story.repository.StoryJdbcRepository;
+import com.earseo.story.repository.StorySpotSummaryJdbcRepository;
+import com.earseo.story.service.OpenAiService.SpotSummaryResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("이야기 요약 시 ")
+class StorySpotSummaryServiceTest {
+
+    @Mock
+    private OpenAiService openAiService;
+
+    @Mock
+    private StoryJdbcRepository storyJDBCRepository;
+
+    @Mock
+    private StorySpotSummaryJdbcRepository storySpotSummaryJDBCRepository;
+
+    @InjectMocks
+    private StorySpotSummaryService storySpotSummaryService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(storySpotSummaryService, "HOT_SPOT_THRESHOLD", 30);
+        ReflectionTestUtils.setField(storySpotSummaryService, "STORY_SUMMARY_LIMIT", 3);
+        ReflectionTestUtils.setField(storySpotSummaryService, "STORY_SUMMARY_THRESHOLD", 3);
+    }
+
+    @Test
+    @DisplayName("핫스팟이 없으면 요약을 생성하지 않는다")
+    void createSummariesScheduled_NoHotSpots_DoesNotCreateSummaries() {
+        // given
+        given(storyJDBCRepository.findHotStorySpot(30))
+            .willReturn(Collections.emptyList());
+
+        // when
+        storySpotSummaryService.createSummariesScheduled();
+
+        // then
+        then(storySpotSummaryJDBCRepository).should(never())
+            .findAllLastSummarizedStoryIdSet(anyList());
+        then(storyJDBCRepository).should(never())
+            .findAllHotStorySummarizeTargetStory(anyList(), anyInt());
+        then(storySpotSummaryJDBCRepository).should(never())
+            .batchUpsert(anyList());
+    }
+
+    @Test
+    @DisplayName("이야기 스팟의 이야기 컨셉의 이야기 개수가 조건을 만족하지 않으면 요약을 생성하지 않는다")
+    void createSummariesScheduled_BelowThreshold_DoesNotCreateSummary() {
+        // given
+        List<Long> hotSpotIds = List.of(1L);
+
+        Story story1 = createStory(1L, "content1");
+        Story story2 = createStory(2L, "content2");
+        Set<Story> stories = Set.of(story1, story2);
+
+        Map<Long, Map<StoryConcept, Set<Story>>> currentStories = Map.of(
+            1L, Map.of(StoryConcept.EXPERIENCE, stories)
+        );
+
+        given(storyJDBCRepository.findHotStorySpot(30)).willReturn(hotSpotIds);
+        given(storySpotSummaryJDBCRepository.findAllLastSummarizedStoryIdSet(hotSpotIds))
+            .willReturn(Collections.emptyMap());
+        given(storyJDBCRepository.findAllHotStorySummarizeTargetStory(hotSpotIds, 3))
+            .willReturn(currentStories);
+
+        // when
+        storySpotSummaryService.createSummariesScheduled();
+
+        // then
+        then(openAiService).should(never())
+            .generateSummaryWithAI(anySet(), any(), any());
+        then(storySpotSummaryJDBCRepository).should(never())
+            .batchUpsert(anyList());
+    }
+
+    @Test
+    @DisplayName("이전의 요약 생성 조건과 같은 이야기 구성이면 요약을 생성하지 않는다")
+    void createSummariesScheduled_SameStoryIds_DoesNotCreateSummary() {
+        // given
+        List<Long> hotSpotIds = List.of(1L);
+
+        Map<Long, Map<StoryConcept, Set<Long>>> lastSummaries = Map.of(
+            1L, Map.of(StoryConcept.EXPERIENCE, Set.of(1L, 2L, 3L))
+        );
+
+        // 이전 요약과 동일한 이야기
+        Story story1 = createStory(1L, "content1");
+        Story story2 = createStory(2L, "content2");
+        Story story3 = createStory(3L, "content3");
+        Set<Story> stories = Set.of(story1, story2, story3);
+
+        Map<Long, Map<StoryConcept, Set<Story>>> currentStories = Map.of(
+            1L, Map.of(StoryConcept.EXPERIENCE, stories)
+        );
+
+        given(storyJDBCRepository.findHotStorySpot(30)).willReturn(hotSpotIds);
+        given(storySpotSummaryJDBCRepository.findAllLastSummarizedStoryIdSet(hotSpotIds))
+            .willReturn(lastSummaries);
+        given(storyJDBCRepository.findAllHotStorySummarizeTargetStory(hotSpotIds, 3))
+            .willReturn(currentStories);
+
+        // when
+        storySpotSummaryService.createSummariesScheduled();
+
+        // then
+        then(openAiService).should(never())
+            .generateSummaryWithAI(anySet(), any(), any());
+        then(storySpotSummaryJDBCRepository).should(never())
+            .batchUpsert(anyList());
+    }
+
+    @Test
+    @DisplayName("새로운 스토리가 있으면 모든 Locale에 대해 요약을 생성한다")
+    void createSummariesScheduled_NewStories_CreatesSummariesForAllLocales() {
+        // given
+        List<Long> hotSpotIds = List.of(1L);
+
+        Story story1 = createStory(1L, "content1");
+        Story story2 = createStory(2L, "content2");
+        Story story3 = createStory(3L, "content3");
+        Set<Story> stories = Set.of(story1, story2, story3);
+
+        Map<Long, Map<StoryConcept, Set<Story>>> currentStories = Map.of(
+            1L, Map.of(StoryConcept.EXPERIENCE, stories)
+        );
+
+        // 이전 요약과 다른 ID
+        Map<Long, Map<StoryConcept, Set<Long>>> lastSummaries = Map.of(
+            1L, Map.of(StoryConcept.EXPERIENCE, Set.of(4L, 5L, 6L))
+        );
+
+        SpotSummaryResult mockResult = new SpotSummaryResult("Test Title", "Test Summary");
+
+        given(storyJDBCRepository.findHotStorySpot(30)).willReturn(hotSpotIds);
+        given(storySpotSummaryJDBCRepository.findAllLastSummarizedStoryIdSet(hotSpotIds))
+            .willReturn(lastSummaries);
+        given(storyJDBCRepository.findAllHotStorySummarizeTargetStory(hotSpotIds, 3))
+            .willReturn(currentStories);
+        given(openAiService.generateSummaryWithAI(anySet(), any(), any()))
+            .willReturn(mockResult);
+        given(storySpotSummaryJDBCRepository.batchUpsert(anyList()))
+            .willReturn(2L);
+
+        // when
+        storySpotSummaryService.createSummariesScheduled();
+
+        // then
+        // Locale 개수만큼 호출
+        then(openAiService).should(times(2))
+            .generateSummaryWithAI(eq(stories), eq(StoryConcept.EXPERIENCE), any(Locale.class));
+
+        then(storySpotSummaryJDBCRepository).should(times(1))
+            .batchUpsert(argThat(list -> list.size() == 2));
+    }
+
+    private Story createStory(Long id, String content) {
+        return Story.builder()
+            .id(id)
+            .content(content)
+            .storyConcept(StoryConcept.EXPERIENCE)
+            .locale(Locale.KO)
+            .createdAt(LocalDateTime.now())
+            .build();
+    }
+}

--- a/src/test/java/com/earseo/story/service/StorySpotTitleListTest.java
+++ b/src/test/java/com/earseo/story/service/StorySpotTitleListTest.java
@@ -86,7 +86,7 @@ class StorySpotTitleListTest {
 
         List<SpotTitleAggregate> mockAggregates = List.of(aggregate1, aggregate2, aggregate3);
 
-        given(spotTitleAggregateRepository.findTop4TitleBySpotId(eq(storySpotId), any(Pageable.class)))
+        given(spotTitleAggregateRepository.findTopTitleBySpotId(eq(storySpotId), any(Pageable.class)))
             .willReturn(mockAggregates);
 
         // when
@@ -96,7 +96,7 @@ class StorySpotTitleListTest {
         assertThat(response.titles()).hasSize(3);
         assertThat(response.titles()).containsExactly("서울 여행", "맛집 투어", "카페 탐방");
         then(spotTitleAggregateRepository).should(times(1))
-            .findTop4TitleBySpotId(eq(storySpotId), any(Pageable.class));
+            .findTopTitleBySpotId(eq(storySpotId), any(Pageable.class));
     }
 
     @Test
@@ -106,7 +106,7 @@ class StorySpotTitleListTest {
         Long storySpotId = 999L;
         List<SpotTitleAggregate> emptyList = List.of();
 
-        given(spotTitleAggregateRepository.findTop4TitleBySpotId(eq(storySpotId), any(Pageable.class)))
+        given(spotTitleAggregateRepository.findTopTitleBySpotId(eq(storySpotId), any(Pageable.class)))
             .willReturn(emptyList);
 
         // when
@@ -115,7 +115,7 @@ class StorySpotTitleListTest {
         // then
         assertThat(response.titles()).isEmpty();
         then(spotTitleAggregateRepository).should(times(1))
-            .findTop4TitleBySpotId(eq(storySpotId), any(Pageable.class));
+            .findTopTitleBySpotId(eq(storySpotId), any(Pageable.class));
     }
 
     @Test
@@ -135,7 +135,7 @@ class StorySpotTitleListTest {
             createAggregate(4L, storySpot, "제목4", 70L)
         );
 
-        given(spotTitleAggregateRepository.findTop4TitleBySpotId(eq(storySpotId), any(Pageable.class)))
+        given(spotTitleAggregateRepository.findTopTitleBySpotId(eq(storySpotId), any(Pageable.class)))
             .willReturn(mockAggregates);
 
         // when
@@ -202,7 +202,7 @@ class StorySpotTitleListTest {
 
         given(storySpotRepository.findByGeohash(anyString()))
             .willReturn(Optional.of(storySpot));
-        given(spotTitleAggregateRepository.findTop4TitleBySpotId(eq(storySpotId), any(Pageable.class)))
+        given(spotTitleAggregateRepository.findTopTitleBySpotId(eq(storySpotId), any(Pageable.class)))
             .willReturn(mockAggregates);
 
         // when
@@ -214,7 +214,7 @@ class StorySpotTitleListTest {
         assertThat(response.titles()).containsExactly("서울 여행", "맛집 투어");
         then(storySpotRepository).should(times(1)).findByGeohash(anyString());
         then(spotTitleAggregateRepository).should(times(1))
-            .findTop4TitleBySpotId(eq(storySpotId), any(Pageable.class));
+            .findTopTitleBySpotId(eq(storySpotId), any(Pageable.class));
     }
 
     @Test
@@ -235,7 +235,7 @@ class StorySpotTitleListTest {
         assertThat(response.titles()).isEmpty();
         then(storySpotRepository).should(times(1)).findByGeohash(anyString());
         then(spotTitleAggregateRepository).should(never())
-            .findTop4TitleBySpotId(any(), any(Pageable.class));
+            .findTopTitleBySpotId(any(), any(Pageable.class));
     }
 
     @Test
@@ -260,7 +260,7 @@ class StorySpotTitleListTest {
 
         given(storySpotRepository.findByGeohash(anyString()))
             .willReturn(Optional.of(storySpot));
-        given(spotTitleAggregateRepository.findTop4TitleBySpotId(eq(storySpotId), any(Pageable.class)))
+        given(spotTitleAggregateRepository.findTopTitleBySpotId(eq(storySpotId), any(Pageable.class)))
             .willReturn(mockAggregates);
 
         // when


### PR DESCRIPTION
## 🧩 구현/변경 사항
- 이야기 스팟 이야기 요약
- 이야기 스팟의 전체 정보 조회
  - 기본 이야기 스팟 정보
  - 상위 4개 이야기 제목 목록
  - 요청한 좌표로 부터 거리
  - 이야기 스팟의 이야기 목록
  - 이야기 스팟의 요약 목록
- 이야기 스팟의 이야기 목록 조회
  - Slice 단위 조회

---

## 🧪 테스트 결과
<img width="600" height="145" alt="image" src="https://github.com/user-attachments/assets/0b860fe5-584a-4a9e-af82-ab18177c628b" />
<img width="608" height="209" alt="image" src="https://github.com/user-attachments/assets/c66f58d6-b803-4ae9-8d6c-2f5edaaa14a1" />

---

## BREAKING CHANGE (옵션)
- 스케줄러를 통해 실행되는 요약 파이프라인이 다루는 데이터가 많아질 경우를 대비해서 `JdbcTemplate` 기반의 `BatchUpdate`를 활용하여 요약정보를 저장, 수정합니다.
- 요약 정보 저장시에 `BatchUpdate`로 데이터를 저장하기 때문에 hibernate의 dirty check 를 활용할 이유가 없어 조회시에도 Jpa를 사용하지 않고 `JdbcTemplate`을 활용했습니다.
- 이야기 스팟 요약에 활용된 이야기 id를 저장하기 위해서 JSONB 타입을 사용하고 있습니다. JPA에서 직렬화/역직렬화는 `hypersistence` 라이브러리를 통해 자동으로 수행되지만, JdbcTemplate과 같은 hibernate를 거치지 않는 조회 방식에서는 Set<Long>으로 직렬화/역직렬화가 되지 않아 직접 ObjectMapper를 활용해 수행해야합니다.

---

## 참고
- 여러 LLM 설정 관련 환경변수들을 파드 환경변수로 넣을수 있도록 처리했습니다.
- 프롬프트는 간략하게 작성하여 많은 테스트를 거쳐보지는 않았습니다. 한번의 요청에 요청당(스팟, 컨셉, 언어) 500 토큰 정도를 사용하고 있습니다.

---

## 🪞 회고 및 개선 아이디어 (옵션)
- 이야기 스팟의 전체 정보 조회 API에서 활용하고 있는 테이블이 6개이고 5번의 요청을 데이터베이스로 보내고 있습니다. 한방 쿼리를 만들기 어렵겠지만 개발 기간에 여유가 생길때엔 쿼리 요청 횟수를 줄일 방법을 찾아야할것입니다.

closes #6 