### PR TITLE
[#8] 이야기 커뮤니티 기능 개발

### DIFF
--- a/src/main/java/com/earseo/story/common/KafkaEventType.java
+++ b/src/main/java/com/earseo/story/common/KafkaEventType.java
@@ -1,0 +1,10 @@
+package com.earseo.story.common;
+
+public class KafkaEventType {
+    public static final String STORY_UPDATED = "story.updated";
+    public static final String STORY_LIKED = "story.liked";
+    public static final String STORY_REPORTED = "story.reported";
+
+    private KafkaEventType() {
+    }
+}

--- a/src/main/java/com/earseo/story/common/exception/StoryError.java
+++ b/src/main/java/com/earseo/story/common/exception/StoryError.java
@@ -11,6 +11,10 @@ public enum StoryError implements ErrorCodeInterface {
     ITS_NOT_YOU("STR002", "jwt 사용자와 입력 정보가 불일치 합니다.", HttpStatus.CONFLICT),
     STORY_IMAGE_UPLOAD_FAILED("STR003", "이미지 업로드 중 오류가 발생했습니다.", HttpStatus.BAD_REQUEST),
     INVALID_COORDINATE_RANGE("STR004", "최소 위도/경도는 최대 위도/경도보다 작아야 합니다.", HttpStatus.BAD_REQUEST),
+    STORY_NOT_FOUND("STR005", "이야기를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    STORY_NOT_OWNER("STR006", "이야기 작성자만 수정/삭제할 수 있습니다.", HttpStatus.FORBIDDEN),
+    STORY_ALREADY_REPORTED("STR007", "이미 신고한 이야기입니다.", HttpStatus.CONFLICT),
+    STORY_ALREADY_LIKED("STR008", "이미 좋아요한 이야기입니다.", HttpStatus.CONFLICT),
     ;
 
     private final String status;

--- a/src/main/java/com/earseo/story/controller/StoryUserController.java
+++ b/src/main/java/com/earseo/story/controller/StoryUserController.java
@@ -3,9 +3,11 @@ package com.earseo.story.controller;
 import com.earseo.story.common.BaseResponse;
 import com.earseo.story.common.exception.BaseException;
 import com.earseo.story.dto.request.CreateRequest;
+import com.earseo.story.dto.request.UpdateStoryRequest;
 import com.earseo.story.dto.response.CreateResponse;
 import com.earseo.story.dto.response.MyStoryListResponse;
 import com.earseo.story.dto.response.ToggleLikeResponse;
+import com.earseo.story.dto.response.UpdateStoryResponse;
 import com.earseo.story.service.StoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -195,5 +197,79 @@ public class StoryUserController {
             @PathVariable Long storyId
     ) {
         return ResponseEntity.ok(BaseResponse.ok(storyService.toggleLike(storyId, memberId)));
+    }
+
+    @Operation(
+            summary = "이야기 수정",
+            description = """
+        작성한 이야기를 수정합니다.
+        - 작성자 본인만 수정 가능
+        - 제목, 내용, 컨셉, 이미지 수정 가능
+        - 이미지는 keepImageUrls로 유지할 이미지를 지정하고, files로 새 이미지 추가
+        - 최종 이미지는 최대 3개까지 가능
+        """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = UpdateStoryResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                    {
+                        "status": "STR006",
+                        "message": "이야기 작성자만 수정/삭제할 수 있습니다.",
+                        "data": null
+                    }
+                    """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "이야기를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                    {
+                        "status": "STR005",
+                        "message": "이야기를 찾을 수 없습니다.",
+                        "data": null
+                    }
+                    """
+                            )
+                    )
+            )
+    })
+    @PatchMapping(value = "/{storyId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<BaseResponse<UpdateStoryResponse>> updateStory(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestHeader("X-USER-ID") Long memberId,
+
+            @Parameter(description = "수정할 이야기 ID", required = true)
+            @PathVariable Long storyId,
+
+            @Parameter(
+                    description = "이야기 수정 요청 바디",
+                    required = true,
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
+            )
+            @Valid @RequestPart UpdateStoryRequest body,
+
+            @Parameter(
+                    description = "새로 추가할 이미지 파일 (최대 3개)",
+                    required = false,
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
+            )
+            @RequestPart(required = false) List<MultipartFile> files
+    ) {
+        return ResponseEntity.ok(BaseResponse.ok(storyService.updateStory(storyId, memberId, body, files)));
     }
 }

--- a/src/main/java/com/earseo/story/controller/StoryUserController.java
+++ b/src/main/java/com/earseo/story/controller/StoryUserController.java
@@ -4,6 +4,7 @@ import com.earseo.story.common.BaseResponse;
 import com.earseo.story.common.exception.BaseException;
 import com.earseo.story.dto.request.CreateRequest;
 import com.earseo.story.dto.response.CreateResponse;
+import com.earseo.story.dto.response.MyStoryListResponse;
 import com.earseo.story.service.StoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -119,5 +120,36 @@ public class StoryUserController {
     ) {
         if (images != null && images.size() > 3) throw new BaseException(STORY_IMAGE_TOO_MANY);
         return ResponseEntity.ok(BaseResponse.ok(storyService.createStory(memberId, body, images)));
+    }
+
+    @Operation(
+            summary = "나의 이야기 목록 조회",
+            description = """
+        로그인한 사용자가 작성한 이야기 목록을 최신순으로 조회합니다.
+        - 무한 스크롤 지원 (Cursor 기반 페이징)
+        - 첫 조회: lastStoryId 없이 호출
+        - 이후 조회: 이전 응답의 lastStoryId를 파라미터로 전달
+        - 이미지, 좋아요 개수, 위치 정보 포함
+        """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = MyStoryListResponse.class))
+            )
+    })
+    @GetMapping("/my")
+    public ResponseEntity<BaseResponse<MyStoryListResponse>> getMyStories(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestHeader("X-USER-ID") Long memberId,
+
+            @Parameter(description = "마지막 이야기 ID (첫 조회 시 생략)", example = "42")
+            @RequestParam(required = false) Long lastStoryId,
+
+            @Parameter(description = "조회할 개수", example = "10")
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ResponseEntity.ok(BaseResponse.ok(storyService.getMyStories(memberId, lastStoryId, size)));
     }
 }

--- a/src/main/java/com/earseo/story/controller/StoryUserController.java
+++ b/src/main/java/com/earseo/story/controller/StoryUserController.java
@@ -5,6 +5,7 @@ import com.earseo.story.common.exception.BaseException;
 import com.earseo.story.dto.request.CreateRequest;
 import com.earseo.story.dto.response.CreateResponse;
 import com.earseo.story.dto.response.MyStoryListResponse;
+import com.earseo.story.dto.response.ToggleLikeResponse;
 import com.earseo.story.service.StoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -151,5 +152,48 @@ public class StoryUserController {
             @RequestParam(defaultValue = "10") int size
     ) {
         return ResponseEntity.ok(BaseResponse.ok(storyService.getMyStories(memberId, lastStoryId, size)));
+    }
+
+    @Operation(
+            summary = "이야기 좋아요 토글",
+            description = """
+        이야기에 좋아요를 추가하거나 취소합니다.
+        - 좋아요가 없으면 추가, 있으면 취소
+        - Redis 캐싱으로 성능 최적화
+        - 응답에 현재 좋아요 상태와 총 개수 포함
+        """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "좋아요 토글 성공",
+                    content = @Content(schema = @Schema(implementation = ToggleLikeResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "이야기를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                    {
+                        "status": "STR005",
+                        "message": "이야기를 찾을 수 없습니다.",
+                        "data": null
+                    }
+                    """
+                            )
+                    )
+            )
+    })
+    @PostMapping("/{storyId}/like")
+    public ResponseEntity<BaseResponse<ToggleLikeResponse>> toggleLike(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestHeader("X-USER-ID") Long memberId,
+
+            @Parameter(description = "좋아요할 이야기 ID", required = true)
+            @PathVariable Long storyId
+    ) {
+        return ResponseEntity.ok(BaseResponse.ok(storyService.toggleLike(storyId, memberId)));
     }
 }

--- a/src/main/java/com/earseo/story/dto/request/ReportStoryRequest.java
+++ b/src/main/java/com/earseo/story/dto/request/ReportStoryRequest.java
@@ -1,0 +1,16 @@
+package com.earseo.story.dto.request;
+
+import com.earseo.story.entity.ReportReason;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ReportStoryRequest(
+        @NotNull(message = "신고 사유는 필수입니다")
+        @Schema(description = "신고 사유", example = "INSULT", requiredMode = Schema.RequiredMode.REQUIRED)
+        ReportReason reason,
+
+        @Size(max = 500, message = "상세 내용은 500자 이하여야 합니다")
+        @Schema(description = "신고 상세 내용", example = "욕설이 포함되어 있습니다")
+        String description
+) {}

--- a/src/main/java/com/earseo/story/dto/request/UpdateStoryRequest.java
+++ b/src/main/java/com/earseo/story/dto/request/UpdateStoryRequest.java
@@ -1,0 +1,23 @@
+package com.earseo.story.dto.request;
+
+import com.earseo.story.entity.StoryConcept;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record UpdateStoryRequest(
+        @Size(min = 1, max = 30, message = "제목은 1자 이상 30자 이하여야 합니다")
+        @Schema(description = "이야기 제목", example = "수정된 제목")
+        String title,
+
+        @Size(min = 1, max = 200, message = "내용은 1자 이상 200자 이하여야 합니다")
+        @Schema(description = "이야기 내용", example = "수정된 내용입니다")
+        String content,
+
+        @Schema(description = "이야기 컨셉", example = "EXPERIENCE")
+        StoryConcept storyConcept,
+
+        @Schema(description = "유지할 이미지 URL 목록")
+        List<String> keepImageUrls
+) {}

--- a/src/main/java/com/earseo/story/dto/response/MyStoryListResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/MyStoryListResponse.java
@@ -1,0 +1,35 @@
+package com.earseo.story.dto.response;
+
+import com.earseo.story.entity.Story;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.Map;
+
+public record MyStoryListResponse(
+        @Schema(description = "이야기 목록")
+        List<MyStoryResponse> stories,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext,
+
+        @Schema(description = "다음 조회 시 사용할 마지막 이야기 ID (null이면 마지막)", example = "42")
+        Long lastStoryId
+) {
+    public static MyStoryListResponse toDto(List<Story> stories, Map<Long, List<String>> imageUrlMap, boolean hasNext) {
+        List<MyStoryResponse> storyResponses = stories.stream()
+                .map(story -> MyStoryResponse.toDto(
+                        story,
+                        imageUrlMap.getOrDefault(story.getId(), List.of())
+                ))
+                .toList();
+
+        Long lastStoryId = stories.isEmpty() ? null : stories.get(stories.size() - 1).getId();
+
+        return new MyStoryListResponse(
+                storyResponses,
+                hasNext,
+                lastStoryId
+        );
+    }
+}

--- a/src/main/java/com/earseo/story/dto/response/MyStoryResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/MyStoryResponse.java
@@ -1,0 +1,59 @@
+package com.earseo.story.dto.response;
+
+import com.earseo.story.entity.Story;
+import com.earseo.story.entity.StoryConcept;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MyStoryResponse(
+        @Schema(description = "이야기 ID", example = "1")
+        Long storyId,
+
+        @Schema(description = "이야기 제목", example = "경복궁 근처 맛집")
+        String title,
+
+        @Schema(description = "이야기 내용", example = "정말 맛있는 카페입니다!")
+        String content,
+
+        @Schema(description = "이야기 컨셉", example = "TIP")
+        StoryConcept storyConcept,
+
+        @Schema(description = "이미지 URL 목록")
+        List<String> imageUrls,
+
+        @Schema(description = "좋아요 개수", example = "15")
+        Long likeCount,
+
+        @Schema(description = "이야기 스팟 ID", example = "1")
+        Long storySpotId,
+
+        @Schema(description = "위도", example = "37.5665")
+        Double latitude,
+
+        @Schema(description = "경도", example = "126.9780")
+        Double longitude,
+
+        @Schema(description = "생성 일시")
+        LocalDateTime createdAt,
+
+        @Schema(description = "수정 일시")
+        LocalDateTime updatedAt
+) {
+    public static MyStoryResponse toDto(Story story, List<String> imageUrls) {
+        return new MyStoryResponse(
+                story.getId(),
+                story.getStoryTitle().getTitle(),
+                story.getContent(),
+                story.getStoryConcept(),
+                imageUrls,
+                story.getLikeCount(),
+                story.getStorySpot().getId(),
+                story.getPoint().getY(),
+                story.getPoint().getX(),
+                story.getCreatedAt(),
+                story.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/earseo/story/dto/response/ToggleLikeResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/ToggleLikeResponse.java
@@ -1,0 +1,11 @@
+package com.earseo.story.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ToggleLikeResponse(
+        @Schema(description = "좋아요 상태", example = "true")
+        boolean isLiked,
+
+        @Schema(description = "현재 좋아요 개수", example = "15")
+        Long likeCount
+) {}

--- a/src/main/java/com/earseo/story/dto/response/UpdateStoryResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/UpdateStoryResponse.java
@@ -1,0 +1,13 @@
+package com.earseo.story.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record UpdateStoryResponse(
+        @Schema(description = "이야기 ID", example = "1")
+        Long storyId,
+
+        @Schema(description = "수정 일시")
+        LocalDateTime updatedAt
+) {}

--- a/src/main/java/com/earseo/story/entity/ReportReason.java
+++ b/src/main/java/com/earseo/story/entity/ReportReason.java
@@ -1,0 +1,18 @@
+package com.earseo.story.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReportReason {
+    ADVERTISEMENT("영리목적/홍보성"),
+    COPYRIGHT("저작권침해"),
+    SEXUAL("음란성/선정성"),
+    INSULT("욕설/인신공격"),
+    PRIVACY("개인정보노출"),
+    DUPLICATE("같은내용 반복게시"),
+    ETC("기타");
+
+    private final String description;
+}

--- a/src/main/java/com/earseo/story/entity/Story.java
+++ b/src/main/java/com/earseo/story/entity/Story.java
@@ -47,4 +47,14 @@ public class Story {
     private LocalDateTime createdAt;
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    public void incrementLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decrementLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
 }

--- a/src/main/java/com/earseo/story/entity/Story.java
+++ b/src/main/java/com/earseo/story/entity/Story.java
@@ -57,4 +57,16 @@ public class Story {
             this.likeCount--;
         }
     }
+
+    public void updateStory(StoryTitle newTitle, String newContent, StoryConcept newConcept) {
+        if (newTitle != null) {
+            this.storyTitle = newTitle;
+        }
+        if (newContent != null) {
+            this.content = newContent;
+        }
+        if (newConcept != null) {
+            this.storyConcept = newConcept;
+        }
+    }
 }

--- a/src/main/java/com/earseo/story/entity/StoryLike.java
+++ b/src/main/java/com/earseo/story/entity/StoryLike.java
@@ -1,0 +1,42 @@
+package com.earseo.story.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        uniqueConstraints = @UniqueConstraint(
+                name = "story_like_unique",
+                columnNames = {"story_id", "member_id"}
+        ),
+        indexes = @Index(name = "idx_story_like_story", columnList = "story_id")
+)
+public class StoryLike {
+    @Id
+    @Column(name = "story_like_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "story_id", nullable = false)
+    private Story story;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/earseo/story/entity/StoryReport.java
+++ b/src/main/java/com/earseo/story/entity/StoryReport.java
@@ -1,0 +1,49 @@
+package com.earseo.story.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        uniqueConstraints = @UniqueConstraint(
+                name = "story_report_unique",
+                columnNames = {"story_id", "reporter_id"}
+        ),
+        indexes = @Index(name = "idx_story_report_story", columnList = "story_id")
+)
+public class StoryReport {
+    @Id
+    @Column(name = "story_report_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "story_id", nullable = false)
+    private Story story;
+
+    @Column(name = "reporter_id", nullable = false)
+    private Long reporterId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReportReason reason;
+
+    @Column(length = 500)
+    private String description;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/earseo/story/repository/SpotTitleAggregateRepository.java
+++ b/src/main/java/com/earseo/story/repository/SpotTitleAggregateRepository.java
@@ -85,4 +85,21 @@ public interface SpotTitleAggregateRepository extends JpaRepository<SpotTitleAgg
         @Param("maxLat") Double maxLatitude,
         @Param("limit") Integer limit
     );
+
+    @Modifying
+    @Query(value = """
+    INSERT INTO spot_title_aggregate (story_spot_id, story_title_id, story_count, updated_at)
+    VALUES (:storySpotId, :storyTitleId, -1, CURRENT_TIMESTAMP)
+    ON CONFLICT ON CONSTRAINT spot_title_unique_constraint
+    DO UPDATE SET
+        story_count = spot_title_aggregate.story_count - 1,
+        updated_at = CURRENT_TIMESTAMP;
+    
+    DELETE FROM spot_title_aggregate 
+    WHERE story_spot_id = :storySpotId 
+      AND story_title_id = :storyTitleId 
+      AND story_count <= 0
+    """, nativeQuery = true)
+    void decrementOrDelete(@Param("storySpotId") Long storySpotId,
+                           @Param("storyTitleId") Long storyTitleId);
 }

--- a/src/main/java/com/earseo/story/repository/StoryImageRepository.java
+++ b/src/main/java/com/earseo/story/repository/StoryImageRepository.java
@@ -2,6 +2,13 @@ package com.earseo.story.repository;
 
 import com.earseo.story.entity.StoryImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface StoryImageRepository extends JpaRepository<StoryImage, Long> {
+
+    @Query("SELECT si FROM StoryImage si WHERE si.story.id IN :storyIds ORDER BY si.story.id, si.createdAt")
+    List<StoryImage> findByStoryIdIn(@Param("storyIds") List<Long> storyIds);
 }

--- a/src/main/java/com/earseo/story/repository/StoryImageRepository.java
+++ b/src/main/java/com/earseo/story/repository/StoryImageRepository.java
@@ -2,6 +2,7 @@ package com.earseo.story.repository;
 
 import com.earseo.story.entity.StoryImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -11,4 +12,13 @@ public interface StoryImageRepository extends JpaRepository<StoryImage, Long> {
 
     @Query("SELECT si FROM StoryImage si WHERE si.story.id IN :storyIds ORDER BY si.story.id, si.createdAt")
     List<StoryImage> findByStoryIdIn(@Param("storyIds") List<Long> storyIds);
+
+    // 수정 시 이미지 확인용
+    List<StoryImage> findByStoryId(Long storyId);
+
+    // keepUrls에 없는 이미지 삭제 -> 남길 것만 명시하면 나머지는 자동으로 삭제 처리
+    @Modifying
+    @Query("DELETE FROM StoryImage si WHERE si.story.id = :storyId AND si.imageUrl NOT IN :keepUrls")
+    void deleteByStoryIdAndImageUrlNotIn(@Param("storyId") Long storyId,
+                                         @Param("keepUrls") List<String> keepUrls);
 }

--- a/src/main/java/com/earseo/story/repository/StoryLikeRepository.java
+++ b/src/main/java/com/earseo/story/repository/StoryLikeRepository.java
@@ -1,0 +1,13 @@
+package com.earseo.story.repository;
+
+import com.earseo.story.entity.StoryLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface StoryLikeRepository extends JpaRepository<StoryLike, Long> {
+
+    Optional<StoryLike> findByStoryIdAndMemberId(Long storyId, Long memberId);
+
+    boolean existsByStoryIdAndMemberId(Long storyId, Long memberId);
+}

--- a/src/main/java/com/earseo/story/repository/StoryReportRepository.java
+++ b/src/main/java/com/earseo/story/repository/StoryReportRepository.java
@@ -1,0 +1,7 @@
+package com.earseo.story.repository;
+
+import com.earseo.story.entity.StoryReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoryReportRepository extends JpaRepository<StoryReport, Long> {
+}

--- a/src/main/java/com/earseo/story/repository/StoryRepository.java
+++ b/src/main/java/com/earseo/story/repository/StoryRepository.java
@@ -1,7 +1,25 @@
 package com.earseo.story.repository;
 
 import com.earseo.story.entity.Story;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface StoryRepository extends JpaRepository<Story, Long> {
+
+    // 첫 조회 (lastStoryId 없을 때)
+    @EntityGraph(attributePaths = {"storySpot", "storyTitle", "storyAuthor"})
+    @Query("SELECT s FROM Story s WHERE s.storyAuthor.id = :authorId ORDER BY s.id DESC")
+    List<Story> findByStoryAuthorIdOrderByIdDesc(@Param("authorId") Long authorId,
+                                                 org.springframework.data.domain.Pageable pageable);
+
+    // 이후 조회 (lastStoryId 있을 때)
+    @EntityGraph(attributePaths = {"storySpot", "storyTitle", "storyAuthor"})
+    @Query("SELECT s FROM Story s WHERE s.storyAuthor.id = :authorId AND s.id < :lastStoryId ORDER BY s.id DESC")
+    List<Story> findByStoryAuthorIdAndIdLessThanOrderByIdDesc(@Param("authorId") Long authorId,
+                                                              @Param("lastStoryId") Long lastStoryId,
+                                                              org.springframework.data.domain.Pageable pageable);
 }

--- a/src/main/java/com/earseo/story/service/LikeService.java
+++ b/src/main/java/com/earseo/story/service/LikeService.java
@@ -1,0 +1,117 @@
+package com.earseo.story.service;
+
+import com.earseo.story.common.exception.BaseException;
+import com.earseo.story.entity.Story;
+import com.earseo.story.entity.StoryLike;
+import com.earseo.story.repository.StoryLikeRepository;
+import com.earseo.story.repository.StoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.earseo.story.common.exception.StoryError.STORY_NOT_FOUND;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private static final String LIKE_KEY_PREFIX = "story:like:";
+    private static final String LIKE_COUNT_KEY_PREFIX = "story:like:count:";
+    private static final long CACHE_TTL_HOURS = 24;
+
+    private final StoryRepository storyRepository;
+    private final StoryLikeRepository storyLikeRepository;
+    private final RedisTemplate<String, String> stringTemplate;
+
+    @Transactional
+    public boolean toggleLike(Long storyId, Long memberId) {
+        Story story = storyRepository.findById(storyId)
+                .orElseThrow(() -> new BaseException(STORY_NOT_FOUND));
+
+        String likeKey = LIKE_KEY_PREFIX + storyId + ":" + memberId;
+        String countKey = LIKE_COUNT_KEY_PREFIX + storyId;
+
+        // 좋아요 존재 여부 확인
+        boolean isLiked = storyLikeRepository.existsByStoryIdAndMemberId(storyId, memberId);
+
+        if (isLiked) {
+            // 좋아요 취소
+            StoryLike storyLike = storyLikeRepository.findByStoryIdAndMemberId(storyId, memberId)
+                    .orElseThrow(() -> new BaseException(STORY_NOT_FOUND));
+            storyLikeRepository.delete(storyLike);
+            story.decrementLikeCount();
+
+            // Redis 캐시 삭제
+            stringTemplate.delete(likeKey);
+            stringTemplate.opsForValue().decrement(countKey);
+
+            return false;
+        } else {
+            // 좋아요 추가
+            StoryLike storyLike = StoryLike.builder()
+                    .story(story)
+                    .memberId(memberId)
+                    .build();
+            storyLikeRepository.save(storyLike);
+            story.incrementLikeCount();
+
+            // Redis 캐시 저장
+            stringTemplate.opsForValue().set(likeKey, "1", CACHE_TTL_HOURS, TimeUnit.HOURS);
+            stringTemplate.opsForValue().increment(countKey);
+            stringTemplate.expire(countKey, CACHE_TTL_HOURS, TimeUnit.HOURS);
+
+            return true;
+        }
+    }
+
+    public Long getLikeCount(Long storyId) {
+        String countKey = LIKE_COUNT_KEY_PREFIX + storyId;
+
+        // Redis에서 먼저 조회
+        Object cachedCount = stringTemplate.opsForValue().get(countKey);
+        if (cachedCount != null) {
+            // Integer 또는 String 타입 모두 처리
+            if (cachedCount instanceof String) {
+                return Long.parseLong((String) cachedCount);
+            } else if (cachedCount instanceof Number) {
+                return ((Number) cachedCount).longValue();
+            }
+        }
+
+        // Redis에 없으면 DB 조회
+        Story story = storyRepository.findById(storyId)
+                .orElseThrow(() -> new BaseException(STORY_NOT_FOUND));
+
+        Long likeCount = story.getLikeCount();
+
+        // Redis에 캐싱
+        stringTemplate.opsForValue().set(countKey, String.valueOf(likeCount), CACHE_TTL_HOURS, TimeUnit.HOURS);
+
+        return likeCount;
+    }
+
+    public boolean isLiked(Long storyId, Long memberId) {
+        String likeKey = LIKE_KEY_PREFIX + storyId + ":" + memberId;
+
+        // Redis에서 먼저 조회
+        Boolean exists = stringTemplate.hasKey(likeKey);
+        if (Boolean.TRUE.equals(exists)) {
+            return true;
+        }
+
+        // Redis에 없으면 DB 조회
+        boolean isLiked = storyLikeRepository.existsByStoryIdAndMemberId(storyId, memberId);
+
+        // 좋아요 되어있으면 Redis에 캐싱
+        if (isLiked) {
+            stringTemplate.opsForValue().set(likeKey, "1", CACHE_TTL_HOURS, TimeUnit.HOURS);
+        }
+
+        return isLiked;
+    }
+}

--- a/src/main/java/com/earseo/story/service/StoryService.java
+++ b/src/main/java/com/earseo/story/service/StoryService.java
@@ -42,6 +42,7 @@ public class StoryService {
     private final StoryImageRepository storyImageRepository;
     private final StoryTitleRepository storyTitleRepository;
     private final SpotTitleAggregateRepository spotTitleAggregateRepository;
+    private final LikeService likeService;
 
     @Transactional
     public CreateResponse createStory(Long memberId, CreateRequest body, List<MultipartFile> images) {
@@ -263,5 +264,12 @@ public class StoryService {
         }
 
         return MyStoryListResponse.toDto(stories, imageUrlMap, hasNext);
+    }
+
+    @Transactional
+    public ToggleLikeResponse toggleLike(Long storyId, Long memberId) {
+        boolean isLiked = likeService.toggleLike(storyId, memberId);
+        Long likeCount = likeService.getLikeCount(storyId);
+        return new ToggleLikeResponse(isLiked, likeCount);
     }
 }

--- a/src/main/java/com/earseo/story/service/StoryService.java
+++ b/src/main/java/com/earseo/story/service/StoryService.java
@@ -4,6 +4,7 @@ import ch.hsr.geohash.GeoHash;
 import ch.hsr.geohash.WGS84Point;
 import com.earseo.story.common.exception.BaseException;
 import com.earseo.story.dto.request.CreateRequest;
+import com.earseo.story.dto.request.UpdateStoryRequest;
 import com.earseo.story.dto.response.*;
 import com.earseo.story.entity.*;
 import com.earseo.story.repository.*;
@@ -271,5 +272,91 @@ public class StoryService {
         boolean isLiked = likeService.toggleLike(storyId, memberId);
         Long likeCount = likeService.getLikeCount(storyId);
         return new ToggleLikeResponse(isLiked, likeCount);
+    }
+
+    @Transactional
+    public UpdateStoryResponse updateStory(Long storyId, Long memberId, UpdateStoryRequest request, List<MultipartFile> newImages) {
+        // Story 조회 및 작성자 검증
+        Story story = storyRepository.findById(storyId)
+                .orElseThrow(() -> new BaseException(STORY_NOT_FOUND));
+
+        if (!story.getStoryAuthor().getId().equals(memberId)) {
+            throw new BaseException(STORY_NOT_OWNER);
+        }
+
+        // 제목 변경 처리
+        if (request.title() != null && !request.title().equals(story.getStoryTitle().getTitle())) {
+            // 기존 제목 카운트 감소
+            spotTitleAggregateRepository.decrementOrDelete(
+                    story.getStorySpot().getId(),
+                    story.getStoryTitle().getId()
+            );
+
+            // 새 제목 조회 또는 생성
+            StoryTitle newTitle = storyTitleRepository.findByTitle(request.title())
+                    .orElseGet(() -> storyTitleRepository.save(
+                            StoryTitle.builder()
+                                    .title(request.title())
+                                    .build()
+                    ));
+
+            // 새 제목 카운트 증가
+            spotTitleAggregateRepository.incrementOrCreate(
+                    story.getStorySpot().getId(),
+                    newTitle.getId()
+            );
+
+        }
+
+        // 내용/컨셉 변경
+        String newContent = request.content() != null ? request.content() : story.getContent();
+        StoryConcept newConcept = request.storyConcept() != null ? request.storyConcept() : story.getStoryConcept();
+
+        // 이미지 처리
+        List<StoryImage> existingImages = storyImageRepository.findByStoryId(storyId);
+        List<String> keepUrls = request.keepImageUrls() != null ? request.keepImageUrls() : List.of();
+
+        // 삭제할 이미지 S3에서 제거
+        existingImages.stream()
+                .filter(img -> !keepUrls.contains(img.getImageUrl()))
+                .forEach(img -> {
+                    try {
+                        s3Service.deleteFile(img.getImageUrl());
+                    } catch (Exception e) {
+                        log.error("이미지 삭제 실패: {}", img.getImageUrl(), e);
+                    }
+                });
+
+        // DB에서 삭제
+        if (!keepUrls.isEmpty()) {
+            storyImageRepository.deleteByStoryIdAndImageUrlNotIn(storyId, keepUrls);
+        } else {
+            // keepUrls가 비어있으면 모든 이미지 삭제
+            storyImageRepository.deleteAll(existingImages);
+        }
+
+        // 새 이미지 업로드 및 저장
+        int currentImageCount = keepUrls.size();
+        if (newImages != null && !newImages.isEmpty()) {
+            if (currentImageCount + newImages.size() > 3) {
+                throw new BaseException(STORY_IMAGE_TOO_MANY);
+            }
+
+            List<StoryImage> newStoryImages = getImageList(
+                    newImages,
+                    story.getStorySpot().getGeohash(),
+                    story
+            );
+            storyImageRepository.saveAll(newStoryImages);
+        }
+
+        // Story 엔티티 업데이트
+        StoryTitle titleToUpdate = null;
+        if (request.title() != null && !request.title().equals(story.getStoryTitle().getTitle())) {
+            titleToUpdate = storyTitleRepository.findByTitle(request.title()).orElseThrow();
+        }
+        story.updateStory(titleToUpdate, newContent, newConcept);
+
+        return new UpdateStoryResponse(story.getId(), story.getUpdatedAt());
     }
 }

--- a/src/main/java/com/earseo/story/service/StoryService.java
+++ b/src/main/java/com/earseo/story/service/StoryService.java
@@ -14,15 +14,14 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.earseo.story.common.exception.StoryError.*;
 
@@ -226,5 +225,43 @@ public class StoryService {
             limit
         );
         return SearchSpotInfoList.toDto(responses);
+    }
+
+    @Transactional(readOnly = true)
+    public MyStoryListResponse getMyStories(Long memberId, Long lastStoryId, int size) {
+        // size + 1개 조회해서 hasNext 판단
+        Pageable pageable = PageRequest.of(0, size + 1);
+
+        List<Story> stories;
+        if (lastStoryId == null) {
+            // 첫 조회
+            stories = storyRepository.findByStoryAuthorIdOrderByIdDesc(memberId, pageable);
+        } else {
+            // 이후 조회
+            stories = storyRepository.findByStoryAuthorIdAndIdLessThanOrderByIdDesc(memberId, lastStoryId, pageable);
+        }
+
+        // hasNext 판단
+        boolean hasNext = stories.size() > size;
+        if (hasNext) {
+            stories = stories.subList(0, size); // 실제 size만큼만 반환
+        }
+
+        // 이미지 조회 (N+1 방지)
+        List<Long> storyIds = stories.stream()
+                .map(Story::getId)
+                .toList();
+
+        Map<Long, List<String>> imageUrlMap = Map.of();
+        if (!storyIds.isEmpty()) {
+            List<StoryImage> storyImages = storyImageRepository.findByStoryIdIn(storyIds);
+            imageUrlMap = storyImages.stream()
+                    .collect(Collectors.groupingBy(
+                            si -> si.getStory().getId(),
+                            Collectors.mapping(StoryImage::getImageUrl, Collectors.toList())
+                    ));
+        }
+
+        return MyStoryListResponse.toDto(stories, imageUrlMap, hasNext);
     }
 }


### PR DESCRIPTION
## 🧩 구현/변경 사항
- 이야기 커뮤니티 기능 개발
- 나의 이야기 목록 조회
- 이야기 수정
- 이야기 좋아요
- 이야기 신고 (추후에 카프카 연동과 같이 개발해서 붙일 예정)
---

## 사용자 시나리오(UML)

---

## 🧪 테스트 결과

---

## BREAKING CHANGE (옵션)
- <호환성 깨짐 / API 변경 / 클라이언트 수정 필요 사항>
- (예: `/user/{userId}/alert` → `/user/queue/alert` 변경, timestamp 포맷 KST 필수 등)

---

## 참고
- 기타 후속 작업이나 주의사항
- (예: JWT 인증은 추후 연동 예정, 로깅 레벨은 임시 상향 조정 등)

---

## 🪞 회고 및 개선 아이디어 (옵션)

---

## 💬 리뷰 받고 싶은 부분 (옵션)
