### PR TITLE
[#10] 경로상 팟플레이스 및 요약 조회 API

### DIFF
--- a/src/main/java/com/earseo/story/controller/InternalStoryController.java
+++ b/src/main/java/com/earseo/story/controller/InternalStoryController.java
@@ -1,0 +1,111 @@
+package com.earseo.story.controller;
+
+import com.earseo.story.common.BaseResponse;
+import com.earseo.story.dto.request.GetRouteListSpotRequest;
+import com.earseo.story.dto.response.GetRouteListSpotResponse;
+import com.earseo.story.service.StorySpotSummaryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/internal/story")
+@RequiredArgsConstructor
+public class InternalStoryController {
+    private final StorySpotSummaryService storySpotSummaryService;
+
+    @Operation(
+        summary = "경로 주변 이야기 스팟 조회 (내부 API)",
+        description = """
+            여러 경로(LineString)를 입력받아 각 경로 주변의 요약이 있는 이야기 스팟을 조회합니다.
+            
+            **기능**
+            - 각 경로마다 지정된 거리(meters) 내의 스팟을 검색합니다
+            - 경로당 최대 개수(amount)만큼 스팟을 반환합니다
+            - 이야기 개수가 많은 스팟을 우선적으로 반환합니다
+            - storyConcept가 null이면 랜덤하게 선택합니다
+            
+            **반환값**
+            - 요약이 없는 경로는 해당 인덱스에 null로 반환됩니다
+            - 결과는 요청한 경로 순서와 동일하게 반환됩니다
+            - 각 경로별로 이야기 개수가 많은 순서로 정렬됩니다
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "조회 성공",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                schema = @Schema(implementation = GetRouteListSpotResponse.class),
+                examples = @ExampleObject(
+                    name = "성공 응답 예시",
+                    value = """
+                        {
+                            "status": "SUCCESS",
+                            "message": "요청이 성공적으로 처리되었습니다",
+                            "data": {
+                                "spotList": [
+                                    [
+                                        {
+                                            "longitude": 126.9780,
+                                            "latitude": 37.5665,
+                                            "storySpotId": 1,
+                                            "summaryId": 10,
+                                            "title": "서울 시청",
+                                            "summaryTitle": "서울 시청 주변 맛집 완전 정복",
+                                            "storyConcept": "TIP",
+                                            "docentUrl": "https://cdn.example.com/docent/1.mp3"
+                                        },
+                                        {
+                                            "longitude": 126.9790,
+                                            "latitude": 37.5670,
+                                            "storySpotId": 2,
+                                            "summaryId": 11,
+                                            "title": "시청 우체국",
+                                            "summaryTitle": "숨은 카페 명소",
+                                            "storyConcept": "TIP",
+                                            "docentUrl": "https://cdn.example.com/docent/2.mp3"
+                                        }
+                                    ],
+                                    null,
+                                    [
+                                        {
+                                            "longitude": 127.0276,
+                                            "latitude": 37.4979,
+                                            "storySpotId": 5,
+                                            "summaryId": 20,
+                                            "title": "강남역 4번출구",
+                                            "summaryTitle": "강남의 역사적 변천",
+                                            "storyConcept": "HISTORY",
+                                            "docentUrl": "https://cdn.example.com/docent/5.mp3"
+                                        }
+                                    ]
+                                ]
+                            }
+                        }
+                        """
+                )
+            )
+        ),
+    })
+    @PostMapping("/path/spots")
+    public ResponseEntity<BaseResponse<GetRouteListSpotResponse>> getPathsSpotList(
+        @RequestBody @Valid
+        GetRouteListSpotRequest request
+    ) {
+        return ResponseEntity.ok(BaseResponse.ok(storySpotSummaryService.getPathsSpotList(request)));
+    }
+}

--- a/src/main/java/com/earseo/story/dto/request/GetRouteListSpotRequest.java
+++ b/src/main/java/com/earseo/story/dto/request/GetRouteListSpotRequest.java
@@ -1,0 +1,33 @@
+package com.earseo.story.dto.request;
+
+import com.earseo.story.entity.StoryConcept;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+public record GetRouteListSpotRequest(
+    @Schema(
+        description = "경로 목록",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+        minLength = 1
+    )
+    @NotNull
+    List<PathLineStringRequest> paths,
+    @Schema(
+        description = "요청할 이야기 컨셉 (null로 보낼시 랜덤하게 선정 후 반환)",
+        example = "TIP",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    StoryConcept storyConcept,
+    @Schema(
+        description = "탐색을 할 요약이 있는 스팟의 경로로 부터 떨어진 최대 거리",
+        example = "50",
+        defaultValue = "50",
+        minimum = "5",
+        maximum = "1000",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    Long meters
+) {
+}

--- a/src/main/java/com/earseo/story/dto/request/PathLineStringRequest.java
+++ b/src/main/java/com/earseo/story/dto/request/PathLineStringRequest.java
@@ -1,0 +1,25 @@
+package com.earseo.story.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "경로를 구성하는 점들의 배열")
+public record PathLineStringRequest(
+    @Schema(
+        description = "경로를 구성하는 좌표 목록 (최소 2개 이상)",
+        minLength = 2,
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    List<PointRequest> lineString,
+    @Schema(
+        description = "이 경로에서 반환할 최대 스팟 개수",
+        example = "1",
+        defaultValue = "1",
+        minimum = "0",
+        maximum = "5",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    Long amount
+) {
+}

--- a/src/main/java/com/earseo/story/dto/request/PointRequest.java
+++ b/src/main/java/com/earseo/story/dto/request/PointRequest.java
@@ -1,0 +1,21 @@
+package com.earseo.story.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "위경도 정보")
+public record PointRequest(
+    @Schema(description = "위도", example = "37.5665", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull
+    @DecimalMin(value = "33.0")
+    @DecimalMax(value = "39")
+    Double latitude,
+    @Schema(description = "경도", example = "126.9780", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull
+    @DecimalMin(value = "124")
+    @DecimalMax(value = "133")
+    Double longitude
+) {
+}

--- a/src/main/java/com/earseo/story/dto/response/GetRouteListSpotResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/GetRouteListSpotResponse.java
@@ -1,0 +1,14 @@
+package com.earseo.story.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record GetRouteListSpotResponse(
+    @Schema(description = "요약이 존재하는 이야기 스팟의 정보 (요약이 없는 경로는 요청한 경로 인덱스와 동일한 리스트 인덱스 위치에 null로 반환, 요청 리스트와 순서 동일하게 반환)")
+    List<List<GetRouteSpotResponse>> spotList
+) {
+    static public GetRouteListSpotResponse toDto(List<List<GetRouteSpotResponse>> spotList) {
+        return new GetRouteListSpotResponse(spotList);
+    }
+}

--- a/src/main/java/com/earseo/story/dto/response/GetRouteSpotResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/GetRouteSpotResponse.java
@@ -1,0 +1,37 @@
+package com.earseo.story.dto.response;
+
+import com.earseo.story.entity.StoryConcept;
+import com.earseo.story.repository.projectionDto.StorySpotWithSummaryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GetRouteSpotResponse(
+    @Schema(description = "경도", example = "126.9780")
+    Double longitude,
+    @Schema(description = "위도", example = "37.5665")
+    Double latitude,
+    @Schema(description = "이야기 스팟 ID", example = "1")
+    Long storySpotId,
+    @Schema(description = "이야기 요약 ID", example = "1")
+    Long summaryId,
+    @Schema(description = "이야기 스팟의 가장 많은 이야기 주제", example = "맛집")
+    String title,
+    @Schema(description = "요약 제목", example = "역사적 명소의 종합 요약")
+    String summaryTitle,
+    @Schema(description = "요약의 카테고리", example = "HISTORY")
+    StoryConcept storyConcept,
+    @Schema(description = "요약 도슨트 주소", example = "https://cdn.example.com/docent/audio/1234.mp3")
+    String docentUrl
+) {
+    public static GetRouteSpotResponse toDto(StorySpotWithSummaryProjection spot) {
+        return new GetRouteSpotResponse(
+            spot.getLongitude(),
+            spot.getLatitude(),
+            spot.getStorySpotId(),
+            spot.getSummaryId(),
+            spot.getTopTitle(),
+            spot.getSummaryTitle(),
+            spot.getStoryConcept(),
+            spot.getDocentUrl()
+        );
+    }
+}

--- a/src/main/java/com/earseo/story/repository/StorySpotSummaryRepository.java
+++ b/src/main/java/com/earseo/story/repository/StorySpotSummaryRepository.java
@@ -1,7 +1,9 @@
 package com.earseo.story.repository;
 
 import com.earseo.story.entity.Locale;
+import com.earseo.story.entity.StoryConcept;
 import com.earseo.story.entity.StorySpotSummary;
+import com.earseo.story.repository.projectionDto.StorySpotWithSummaryProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,5 +22,57 @@ public interface StorySpotSummaryRepository extends JpaRepository<StorySpotSumma
     List<StorySpotSummary> findByStorySpotIdAndLocale(
         @Param("storySpotId") Long storySpotId,
         @Param("locale") Locale locale
+    );
+
+    @Query(value = """
+        WITH nearby_spots AS (
+            SELECT 
+                ss.story_spot_id,
+                ss.center,
+                ss.created_at,
+                ST_Distance(
+                    ss.center::geography,
+                    CAST(:path AS geography)
+                ) AS distance
+            FROM story_spot ss
+            WHERE ST_DWithin(ss.center::geography, CAST(:path AS geography), :meters)
+            ORDER BY distance ASC
+        ),
+        top_titles AS (
+            SELECT DISTINCT ON (sta.story_spot_id)
+                sta.story_spot_id,
+                st.title AS top_title,
+                sta.story_count
+            FROM spot_title_aggregate sta
+            JOIN story_title st ON sta.story_title_id = st.story_title_id
+            WHERE sta.story_spot_id IN (SELECT story_spot_id FROM nearby_spots)
+            ORDER BY sta.story_spot_id, sta.story_count DESC, sta.updated_at DESC
+        )
+        SELECT 
+            ns.story_spot_id AS storySpotId,
+            ST_X(ns.center) AS longitude,
+            ST_Y(ns.center) AS latitude,
+            ns.created_at AS createdAt,
+            tt.top_title AS topTitle,
+            sss.story_spot_summary_id AS summaryId,
+            sss.title AS summaryTitle,
+            sss.summary AS summary,
+            sss.story_concept AS storyConcept,
+            sss.docent_url AS docentUrl
+        FROM nearby_spots ns
+        LEFT JOIN top_titles tt ON ns.story_spot_id = tt.story_spot_id
+        LEFT JOIN story_spot_summary sss ON ns.story_spot_id = sss.story_spot_id
+            AND sss.locale = :locale
+            AND (:storyConcept IS NULL OR sss.story_concept = :storyConcept)
+        WHERE sss.story_spot_summary_id IS NOT NULL
+        ORDER BY tt.story_count DESC, ns.distance ASC
+        LIMIT :amount
+        """, nativeQuery = true)
+    List<StorySpotWithSummaryProjection> findSpotsNearPathWithSummaries(
+        @Param("path") org.locationtech.jts.geom.LineString path,
+        @Param("meters") Long meters,
+        @Param("locale") String locale,
+        @Param("storyConcept") String storyConcept,
+        @Param("amount") Long amount
     );
 }

--- a/src/main/java/com/earseo/story/repository/projectionDto/StorySpotWithSummaryProjection.java
+++ b/src/main/java/com/earseo/story/repository/projectionDto/StorySpotWithSummaryProjection.java
@@ -1,0 +1,17 @@
+package com.earseo.story.repository.projectionDto;
+
+import com.earseo.story.entity.StoryConcept;
+import java.time.LocalDateTime;
+
+public interface StorySpotWithSummaryProjection {
+    Long getStorySpotId();
+    Double getLongitude();
+    Double getLatitude();
+    LocalDateTime getCreatedAt();
+    String getTopTitle();
+    Long getSummaryId();
+    String getSummaryTitle();
+    String getSummary();
+    StoryConcept getStoryConcept();
+    String getDocentUrl();
+}

--- a/src/main/java/com/earseo/story/service/StorySpotSummaryService.java
+++ b/src/main/java/com/earseo/story/service/StorySpotSummaryService.java
@@ -1,17 +1,29 @@
 package com.earseo.story.service;
 
+import com.earseo.story.dto.request.GetRouteListSpotRequest;
+import com.earseo.story.dto.request.PathLineStringRequest;
+import com.earseo.story.dto.request.PointRequest;
+import com.earseo.story.dto.response.GetRouteListSpotResponse;
+import com.earseo.story.dto.response.GetRouteSpotResponse;
 import com.earseo.story.entity.Locale;
 import com.earseo.story.entity.Story;
 import com.earseo.story.entity.StoryConcept;
 import com.earseo.story.repository.StoryJdbcRepository;
 import com.earseo.story.repository.StorySpotSummaryJdbcRepository;
 import com.earseo.story.repository.StorySpotSummaryJdbcRepository.SpotSummarySaveRequest;
+import com.earseo.story.repository.StorySpotSummaryRepository;
+import com.earseo.story.repository.projectionDto.StorySpotWithSummaryProjection;
 import com.earseo.story.service.OpenAiService.SpotSummaryResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -27,9 +39,15 @@ public class StorySpotSummaryService {
     @Value("${summary.story-summary.threshold}")
     private int STORY_SUMMARY_THRESHOLD;
 
+    private static final int SRID_WGS84 = 4326;
+    private static final GeometryFactory GEOMETRY_FACTORY =
+        new GeometryFactory(new PrecisionModel(), SRID_WGS84);
+    private static final Random SingletonRandom = new Random();
+
     private final OpenAiService openAiService;
     private final StoryJdbcRepository storyJDBCRepository;
     private final StorySpotSummaryJdbcRepository storySpotSummaryJDBCRepository;
+    private final StorySpotSummaryRepository storySpotSummaryRepository;
 
     @Scheduled(cron = "${summary.schedule.cron}")
     public void createSummariesScheduled() {
@@ -107,5 +125,67 @@ public class StorySpotSummaryService {
             .batchUpsert(spotSummarySaveRequests);
 
         log.info("{} Summary Created", insertedSummaryCnt);
+    }
+
+    @Transactional(readOnly = true)
+    public GetRouteListSpotResponse getPathsSpotList(GetRouteListSpotRequest request) {
+        Long meters = request.meters() != null ? request.meters() : 50L;
+
+        List<List<GetRouteSpotResponse>> spotList = request.paths().stream()
+            .map(path -> processPath(path, meters, request.storyConcept()))
+            .toList();
+
+        return GetRouteListSpotResponse.toDto(spotList);
+    }
+
+    private List<GetRouteSpotResponse> processPath(
+        PathLineStringRequest pathRequest,
+        Long meters,
+        StoryConcept requestedConcept
+    ) {
+        // 유효성 검증
+        if (pathRequest.lineString() == null || pathRequest.lineString().size() < 2 || pathRequest.amount() <= 0) {
+            return List.of();
+        }
+
+        // LineString 생성
+        LineString lineString = buildJTSLineString(pathRequest.lineString());
+
+        // 컨셉이 null이면 가공
+        StoryConcept selectedConcept = requestedConcept != null
+            ? requestedConcept
+            : getRandomConcept();
+
+        // 한방 쿼리
+        List<StorySpotWithSummaryProjection> spotsWithSummaries =
+            storySpotSummaryRepository.findSpotsNearPathWithSummaries(
+                lineString,
+                meters,
+                Locale.KO.name(),
+                selectedConcept.name(),
+                pathRequest.amount()
+            );
+
+        if (spotsWithSummaries.isEmpty()) {
+            return List.of();
+        }
+
+        // 가장 가까운것 반환
+        return spotsWithSummaries.stream().map(GetRouteSpotResponse::toDto).toList();
+    }
+
+    private StoryConcept getRandomConcept() {
+        StoryConcept[] concepts = StoryConcept.values();
+        return concepts[new Random().nextInt(concepts.length)];
+    }
+
+    private LineString buildJTSLineString(List<PointRequest> points) {
+        Coordinate[] coordinates = points.stream()
+            .map(point -> new Coordinate(point.longitude(), point.latitude()))
+            .toArray(Coordinate[]::new);
+
+        LineString lineString = GEOMETRY_FACTORY.createLineString(coordinates);
+        lineString.setSRID(SRID_WGS84);
+        return lineString;
     }
 }


### PR DESCRIPTION
## 🧩 구현/변경 사항
- 경로 주변의 요약이 존재하는 이야기 스팟을 조회하는 내부 API 구현

---

## 참고
- 경로별로 스팟 목록을 반환
  - 리스트의 리스트로 경로상에 여러개의 이야기 스팟도 조회가능
  - 경로 상에 핫스팟이 없거나 경로 형식이 잘못된경우 빈 리스트를 반환

closes #10 