### PR TITLE
[#8] MyStoryResponse DTO 닉네임 반환 추가

### DIFF
--- a/k8s/helm-value.yaml
+++ b/k8s/helm-value.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: v0.1.8
+  tag: v0.1.9
 env:
   HOT_SPOT_THRESHOLD: "30"
   STORY_SUMMARY_LIMIT: "3"

--- a/src/main/java/com/earseo/story/controller/StoryUserController.java
+++ b/src/main/java/com/earseo/story/controller/StoryUserController.java
@@ -11,6 +11,7 @@ import com.earseo.story.dto.response.UpdateStoryResponse;
 import com.earseo.story.service.StoryService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -35,103 +36,28 @@ import static com.earseo.story.common.exception.StoryError.STORY_IMAGE_TOO_MANY;
 public class StoryUserController {
     private final StoryService storyService;
 
-    @PostMapping("/create")
-    public ResponseEntity<BaseResponse<CreateResponse>> createStory(@RequestBody CreateRequest body, @RequestHeader("X-USER-ID") Long memberId) {
-        return ResponseEntity.ok(BaseResponse.ok(storyService.createStory(memberId, body)));
-    }
+    @Operation(
+            summary = "이야기 생성 (이미지 포함)",
+            description = """
+                사용자가 새로운 이야기를 작성합니다.
+                - 최대 3개의 이미지를 함께 업로드할 수 있습니다.
+                """
+    )
+    @PostMapping(value = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<BaseResponse<CreateResponse>> createStory(
+            @RequestHeader("X-USER-ID") Long memberId,
+            @RequestPart("body") String body,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images
+    ) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        CreateRequest request = objectMapper.readValue(body, CreateRequest.class);
 
-    @PostMapping("/image/{id}")
-    public ResponseEntity<BaseResponse<CreateResponse>> saveImages(@RequestParam("images") List<MultipartFile> images,
-                                                                   @RequestHeader("X-USER-ID") Long memberId,
-                                                                   @PathVariable("id") Long storyId) {
-        return ResponseEntity.ok(BaseResponse.ok(storyService.saveImages(images, memberId, storyId)));
+        if (images != null && images.size() > 3) {
+            throw new BaseException(STORY_IMAGE_TOO_MANY);
+        }
+        return ResponseEntity.ok(BaseResponse.ok(storyService.createStory(memberId, request, images)));
     }
-
-//    @Operation(
-//            summary = "이야기 생성",
-//            description = """
-//                    사용자가 새로운 이야기를 작성합니다.
-//                    - 위치 정보(위도/경도)를 기반으로 GeoHash를 생성하여 이야기 스팟에 저장합니다.
-//                    - 최대 3개의 이미지를 함께 업로드할 수 있습니다.
-//                    """
-//    )
-//    @ApiResponses({
-//            @ApiResponse(
-//                    responseCode = "200",
-//                    description = "이야기 생성 성공",
-//                    content = @Content(schema = @Schema(implementation = CreateResponse.class))
-//            ),
-//            @ApiResponse(
-//                    responseCode = "400",
-//                    description = "잘못된 요청",
-//                    content = @Content(
-//                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-//                            examples = {
-//                                    @ExampleObject(
-//                                            name = "이미지 개수 초과",
-//                                            value = """
-//                                                    {
-//                                                        "status": "STR001",
-//                                                        "message": "이야기의 사진은 3개 이하여야 합니다.",
-//                                                        "data": null
-//                                                    }
-//                                                    """
-//                                    ),
-//                                    @ExampleObject(
-//                                            name = "이미지 업로드 실패",
-//                                            value = """
-//                                                    {
-//                                                        "status": "STR003",
-//                                                        "message": "이미지 업로드 중 오류가 발생했습니다.",
-//                                                        "data": null
-//                                                    }
-//                                                    """
-//                                    ),
-//                                    @ExampleObject(
-//                                            name = "유효성 검증 실패",
-//                                            value = """
-//                                                    {
-//                                                      "status": "ARGUMENT_ERROR",
-//                                                      "message": "경도는 124 이상이어야 합니다",
-//                                                      "data": null
-//                                                    }
-//                                                    """
-//                                    )
-//                            }
-//                    )
-//            ),
-//            @ApiResponse(
-//                    responseCode = "409",
-//                    description = "인증 오류",
-//                    content = @Content(
-//                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-//                            examples = @ExampleObject(
-//                                    name = "사용자 불일치",
-//                                    value = """
-//                                            {
-//                                                "status": "STR002",
-//                                                "message": "jwt 사용자와 입력 정보가 불일치 합니다.",
-//                                                "data": null
-//                                            }
-//                                            """
-//                            )
-//                    )
-//            )
-//    })
-    ////    @PostMapping(value = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    ////    public ResponseEntity<BaseResponse<CreateResponse>> createStory(
-    ////            @Parameter(description = "사용자 ID", required = true)
-    ////            @RequestHeader("X-USER-ID") Long memberId,
-    ////            @RequestPart("body") String body,
-    ////            @RequestPart(required = false) List<MultipartFile> images
-    ////    ) throws JsonProcessingException {
-    ////        ObjectMapper objectMapper = new ObjectMapper();
-    ////        CreateRequest request = objectMapper.readValue(body, CreateRequest.class);
-    ////        if (images != null && images.size() > 3) throw new BaseException(STORY_IMAGE_TOO_MANY);
-    ////        return ResponseEntity.ok(BaseResponse.ok(storyService.createStory(memberId, request, images)));
-    ////    }
-    ///
-    ///
 
     @Operation(
             summary = "나의 이야기 목록 조회",
@@ -279,5 +205,27 @@ public class StoryUserController {
             @RequestPart(required = false) List<MultipartFile> files
     ) {
         return ResponseEntity.ok(BaseResponse.ok(storyService.updateStory(storyId, memberId, body, files)));
+    }
+
+    @Operation(
+            summary = "좋아요한 이야기 목록 조회",
+            description = """
+                로그인한 사용자가 좋아요한 이야기 목록을 최신순으로 조회합니다.
+                - 무한 스크롤 지원 (Cursor 기반 페이징)
+                - 첫 조회: lastStoryLikeId 없이 호출
+                - 이후 조회: 이전 응답의 lastStoryId(실제로는 storyLikeId)를 파라미터로 전달
+                """
+    )
+    @GetMapping("/liked")
+    public ResponseEntity<BaseResponse<MyStoryListResponse>> getLikedStories(
+            @RequestHeader("X-USER-ID") Long memberId,
+
+            @Parameter(description = "마지막 좋아요 ID (첫 조회 시 생략)")
+            @RequestParam(required = false) Long lastStoryLikeId,
+
+            @Parameter(description = "조회할 개수", example = "10")
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ResponseEntity.ok(BaseResponse.ok(storyService.getLikedStories(memberId, lastStoryLikeId, size)));
     }
 }

--- a/src/main/java/com/earseo/story/dto/response/MyStoryResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/MyStoryResponse.java
@@ -11,6 +11,9 @@ public record MyStoryResponse(
         @Schema(description = "이야기 ID", example = "1")
         Long storyId,
 
+        @Schema(description = "작성자 닉네임", example = "카피바라")
+        String nickname,
+
         @Schema(description = "이야기 제목", example = "경복궁 근처 맛집")
         String title,
 
@@ -44,6 +47,7 @@ public record MyStoryResponse(
     public static MyStoryResponse toDto(Story story, List<String> imageUrls) {
         return new MyStoryResponse(
                 story.getId(),
+                story.getStoryAuthor().getNickname(),
                 story.getStoryTitle().getTitle(),
                 story.getContent(),
                 story.getStoryConcept(),

--- a/src/main/java/com/earseo/story/dto/response/StoryInfoResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/StoryInfoResponse.java
@@ -9,6 +9,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record StoryInfoResponse(
+    @Schema(description = "이야기 ID", example = "123")
+    Long storyId,
     @Schema(description = "이야기 작성자")
     StoryAuthorResponse storyAuthor,
     @Schema(description = "이야기 제목", example = "경복궁의 맛집")
@@ -30,6 +32,7 @@ public record StoryInfoResponse(
 ) {
     public static StoryInfoResponse toDto(Story story, List<String> imageUrls) {
         return new StoryInfoResponse(
+            story.getId(),
             StoryAuthorResponse.toDto(story.getStoryAuthor()),
             story.getStoryTitle().getTitle(),
             story.getContent(),

--- a/src/main/java/com/earseo/story/repository/StoryLikeRepository.java
+++ b/src/main/java/com/earseo/story/repository/StoryLikeRepository.java
@@ -1,8 +1,12 @@
 package com.earseo.story.repository;
 
 import com.earseo.story.entity.StoryLike;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface StoryLikeRepository extends JpaRepository<StoryLike, Long> {
@@ -10,4 +14,33 @@ public interface StoryLikeRepository extends JpaRepository<StoryLike, Long> {
     Optional<StoryLike> findByStoryIdAndMemberId(Long storyId, Long memberId);
 
     boolean existsByStoryIdAndMemberId(Long storyId, Long memberId);
+
+    @Query("""
+        SELECT sl FROM StoryLike sl
+        JOIN FETCH sl.story s
+        JOIN FETCH s.storyAuthor
+        JOIN FETCH s.storyTitle
+        JOIN FETCH s.storySpot
+        WHERE sl.memberId = :memberId
+        ORDER BY sl.id DESC
+        """)
+    List<StoryLike> findByMemberIdOrderByIdDesc(
+            @Param("memberId") Long memberId,
+            Pageable pageable
+    );
+
+    @Query("""
+        SELECT sl FROM StoryLike sl
+        JOIN FETCH sl.story s
+        JOIN FETCH s.storyAuthor
+        JOIN FETCH s.storyTitle
+        JOIN FETCH s.storySpot
+        WHERE sl.memberId = :memberId AND sl.id < :lastStoryLikeId
+        ORDER BY sl.id DESC
+        """)
+    List<StoryLike> findByMemberIdAndIdLessThanOrderByIdDesc(
+            @Param("memberId") Long memberId,
+            @Param("lastStoryLikeId") Long lastStoryLikeId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/earseo/story/service/StoryService.java
+++ b/src/main/java/com/earseo/story/service/StoryService.java
@@ -49,12 +49,13 @@ public class StoryService {
     private final StoryTitleRepository storyTitleRepository;
     private final SpotTitleAggregateRepository spotTitleAggregateRepository;
     private final StorySpotSummaryRepository storySpotSummaryRepository;
+    private final StoryLikeRepository storyLikeRepository;
     private final LikeService likeService;
 
     @Transactional
-    public CreateResponse createStory(Long memberId, CreateRequest body) {
+    public CreateResponse createStory(Long memberId, CreateRequest body, List<MultipartFile> images) {
         // 사용자 검증
-//        if (!memberId.equals(body.authorId())) throw new BaseException(ITS_NOT_YOU);
+        if (!memberId.equals(body.authorId())) throw new BaseException(ITS_NOT_YOU);
         StoryAuthor storyAuthor = storyAuthorRepository.findById(body.authorId())
                 .orElseGet(() ->
                         storyAuthorRepository.save(
@@ -106,6 +107,11 @@ public class StoryService {
                 .build());
         // 제목 집계 테이블 최신화
         spotTitleAggregateRepository.incrementOrCreate(geohashedSpot.getId(), storyTitle.getId());
+
+        if (images != null && !images.isEmpty()) {
+            List<StoryImage> storyImages = getImageList(images, spotGeoHash, story);
+            storyImageRepository.saveAll(storyImages);
+        }
 
         return CreateResponse.toDto(story);
     }
@@ -288,6 +294,54 @@ public class StoryService {
         boolean isLiked = likeService.toggleLike(storyId, memberId);
         Long likeCount = likeService.getLikeCount(storyId);
         return new ToggleLikeResponse(isLiked, likeCount);
+    }
+
+    @Transactional(readOnly = true)
+    public MyStoryListResponse getLikedStories(Long memberId, Long lastStoryLikeId, int size) {
+        Pageable pageable = PageRequest.of(0, size + 1);
+
+        List<StoryLike> storyLikes;
+        if (lastStoryLikeId == null) {
+            storyLikes = storyLikeRepository.findByMemberIdOrderByIdDesc(memberId, pageable);
+        } else {
+            storyLikes = storyLikeRepository.findByMemberIdAndIdLessThanOrderByIdDesc(memberId, lastStoryLikeId, pageable);
+        }
+
+        boolean hasNext = storyLikes.size() > size;
+        if (hasNext) {
+            storyLikes = storyLikes.subList(0, size);
+        }
+
+        List<Story> stories = storyLikes.stream()
+                .map(StoryLike::getStory)
+                .toList();
+
+        // 이미지 조회
+        List<Long> storyIds = stories.stream()
+                .map(Story::getId)
+                .toList();
+
+        final Map<Long, List<String>> imageUrlMap;
+        if (!storyIds.isEmpty()) {
+            List<StoryImage> storyImages = storyImageRepository.findByStoryIdIn(storyIds);
+            imageUrlMap = storyImages.stream()
+                    .collect(Collectors.groupingBy(
+                            si -> si.getStory().getId(),
+                            Collectors.mapping(StoryImage::getImageUrl, Collectors.toList())
+                    ));
+        } else {
+            imageUrlMap = Map.of();
+        }
+
+        Long lastId = storyLikes.isEmpty() ? null : storyLikes.get(storyLikes.size() - 1).getId();
+
+        return new MyStoryListResponse(
+                stories.stream()
+                        .map(story -> MyStoryResponse.toDto(story, imageUrlMap.getOrDefault(story.getId(), List.of())))
+                        .toList(),
+                hasNext,
+                lastId
+        );
     }
 
     @Transactional

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -74,6 +74,6 @@ cloud:
     region:
       static: ap-northeast-2
     s3:
-      bucket: ${AWS_S#_BUCKET:example-bucket}
+      bucket: ${AWS_S3_BUCKET:example-bucket}
     cloudfront:
       domain: ${AWS_CLOUDFRONT_DOMAIN:cdn.example.com}


### PR DESCRIPTION
## 🧩 구현/변경 사항
- 기존에 MyStoryResponse DTO에서 닉네임 반환 추가

---

## 사용자 시나리오(UML)

---

## 🧪 테스트 결과
```
{
  "status": "OK",
  "message": "요청이 성공적으로 처리되었습니다.",
  "data": {
    "stories": [
      {
        "storyId": 3,
        "nickname": "테스트유저",
        "title": "세번째 이야기",
        "content": "테스트 내용입니다",
        "storyConcept": "TIP",
        "imageUrls": [],
        "likeCount": 0,
        "storySpotId": 1,
        "latitude": 37.5665,
        "longitude": 126.978,
        "createdAt": [
          2025,
          11,
          27,
          0,
          35,
          26,
          630248000
        ],
        "updatedAt": [
          2025,
          11,
          27,
          0,
          35,
          26,
          630248000
        ]
      }
}
```
---

## BREAKING CHANGE (옵션)
- <호환성 깨짐 / API 변경 / 클라이언트 수정 필요 사항>
- (예: `/user/{userId}/alert` → `/user/queue/alert` 변경, timestamp 포맷 KST 필수 등)

---

## 참고
- 기타 후속 작업이나 주의사항
- (예: JWT 인증은 추후 연동 예정, 로깅 레벨은 임시 상향 조정 등)

---

## 🪞 회고 및 개선 아이디어 (옵션)


---

## 💬 리뷰 받고 싶은 부분 (옵션)

