### PR TITLE
[#8] MyStoryResponse StoryAuthorResponse 연결

### DIFF
--- a/k8s/helm-value.yaml
+++ b/k8s/helm-value.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: v0.1.9
+  tag: v0.1.10
 env:
   HOT_SPOT_THRESHOLD: "30"
   STORY_SUMMARY_LIMIT: "3"

--- a/src/main/java/com/earseo/story/dto/response/MyStoryResponse.java
+++ b/src/main/java/com/earseo/story/dto/response/MyStoryResponse.java
@@ -11,8 +11,8 @@ public record MyStoryResponse(
         @Schema(description = "이야기 ID", example = "1")
         Long storyId,
 
-        @Schema(description = "작성자 닉네임", example = "카피바라")
-        String nickname,
+        @Schema(description = "이야기 작성자")
+        StoryAuthorResponse storyAuthor,
 
         @Schema(description = "이야기 제목", example = "경복궁 근처 맛집")
         String title,
@@ -47,7 +47,7 @@ public record MyStoryResponse(
     public static MyStoryResponse toDto(Story story, List<String> imageUrls) {
         return new MyStoryResponse(
                 story.getId(),
-                story.getStoryAuthor().getNickname(),
+                StoryAuthorResponse.toDto(story.getStoryAuthor()),
                 story.getStoryTitle().getTitle(),
                 story.getContent(),
                 story.getStoryConcept(),

--- a/src/main/java/com/earseo/story/service/LikeService.java
+++ b/src/main/java/com/earseo/story/service/LikeService.java
@@ -75,11 +75,17 @@ public class LikeService {
         // Redis에서 먼저 조회
         Object cachedCount = stringTemplate.opsForValue().get(countKey);
         if (cachedCount != null) {
-            // Integer 또는 String 타입 모두 처리
+            Long count;
             if (cachedCount instanceof String) {
-                return Long.parseLong((String) cachedCount);
+                count = Long.parseLong((String) cachedCount);
             } else if (cachedCount instanceof Number) {
-                return ((Number) cachedCount).longValue();
+                count = ((Number) cachedCount).longValue();
+            } else {
+                count = null;
+            }
+
+            if (count != null) {
+                return count;
             }
         }
 


### PR DESCRIPTION
## 🧩 구현/변경 사항
- MyStoryResponse StoryAuthorResponse 연결
- 내 이야기에서 사용자의 닉네임과 프로필 이미지 주소를 동시에 가져오기 위해 StoryAuthorResponse를 사용

---

## BREAKING CHANGE (옵션)
- <호환성 깨짐 / API 변경 / 클라이언트 수정 필요 사항>
- (예: `/user/{userId}/alert` → `/user/queue/alert` 변경, timestamp 포맷 KST 필수 등)

---

## 참고
- 기타 후속 작업이나 주의사항
- (예: JWT 인증은 추후 연동 예정, 로깅 레벨은 임시 상향 조정 등)

---

## 🪞 회고 및 개선 아이디어 (옵션)
- JWT 갱신 로직은 추후 Refresh Token 구조로 개선 예정

---

## 💬 리뷰 받고 싶은 부분 (옵션)
- 토큰 만료 시 처리 로직 괜찮은지 피드백 부탁드립니다.
- UI 로직 구조 개선 제안 환영합니다.
